### PR TITLE
Fix missing Automod action query route

### DIFF
--- a/Valour/Server/Api/Dynamic/PlanetApi.cs
+++ b/Valour/Server/Api/Dynamic/PlanetApi.cs
@@ -406,6 +406,29 @@ public class PlanetApi
         return Results.Json(result);
     }
 
+    [ValourRoute(HttpVerbs.Post, "api/planets/{planetId}/automod/triggers/{triggerId}/actions/query")]
+    [UserRequired(UserPermissionsEnum.PlanetManagement)]
+    public static async Task<IResult> QueryAutomodActionsAsync(
+        [FromBody] QueryRequest? queryRequest,
+        long planetId,
+        Guid triggerId,
+        PlanetMemberService memberService,
+        AutomodService automodService)
+    {
+        if (queryRequest is null)
+            return ValourResult.BadRequest("Include query in body.");
+
+        var member = await memberService.GetCurrentAsync(planetId);
+        if (member is null)
+            return ValourResult.NotPlanetMember();
+
+        if (!await memberService.HasPermissionAsync(member, PlanetPermissions.Manage))
+            return ValourResult.LacksPermission(PlanetPermissions.Manage);
+
+        var result = await automodService.QueryTriggerActionsAsync(triggerId, queryRequest);
+        return Results.Json(result);
+    }
+
     [ValourRoute(HttpVerbs.Get, "api/planets/discoverable")]
     public static async Task<IResult> GetDiscoverables(PlanetService planetService)
     {

--- a/Valour/Server/Services/AutomodService.cs
+++ b/Valour/Server/Services/AutomodService.cs
@@ -56,6 +56,20 @@ public class AutomodService
         };
     }
 
+    public async Task<QueryResponse<AutomodAction>> QueryTriggerActionsAsync(Guid triggerId, QueryRequest request)
+    {
+        var take = Math.Min(50, request.Take);
+        var skip = request.Skip;
+        var query = _db.AutomodActions.Where(x => x.TriggerId == triggerId).AsQueryable();
+        var total = await query.CountAsync();
+        var items = await query.Skip(skip).Take(take).Select(x => x.ToModel()).ToListAsync();
+        return new QueryResponse<AutomodAction>
+        {
+            Items = items,
+            TotalCount = total
+        };
+    }
+
     public async Task<TaskResult<AutomodTrigger>> CreateTriggerAsync(AutomodTrigger trigger)
     {
         trigger.Id = Guid.NewGuid();


### PR DESCRIPTION
## Summary
- add `QueryTriggerActionsAsync` to `AutomodService`
- expose new route `POST /api/planets/{planetId}/automod/triggers/{triggerId}/actions/query`

## Testing
- `dotnet build Valour/Server/Valour.Server.csproj -v q` *(fails: command not found)*
- `dotnet test Valour.Tests/Valour.Tests.csproj` *(fails: command not found)*