### PR TITLE
Refine Automod action workflow

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodActionModal.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodActionModal.razor
@@ -38,7 +38,13 @@
         {
             <div class="form-group mt-2">
                 <label>Role</label>
-                <RoleDropdown Roles="Data.Planet.Roles" Value="_selectedRoleId" ValueChanged="OnRoleChanged" />
+                <select class="form-control" @bind="_selectedRoleId">
+                    <option value="0">Select Role</option>
+                    @foreach (var role in Data.Planet.Roles)
+                    {
+                        <option value="@role.Id">@role.Name</option>
+                    }
+                </select>
             </div>
         }
 
@@ -77,11 +83,6 @@
     private long _selectedRoleId;
     private ITaskResult _result;
 
-    private Task OnRoleChanged(long roleId)
-    {
-        _selectedRoleId = roleId;
-        return Task.CompletedTask;
-    }
 
     protected override void OnInitialized()
     {

--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodTriggerModal.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodTriggerModal.razor
@@ -2,6 +2,8 @@
 @using Valour.Sdk.Models
 @using Valour.Shared.Models.Staff
 @using Valour.Sdk.Requests
+@using Valour.Shared
+@using System
 @inject ValourClient Client
 
 <BasicModalLayout Title="@ModalTitle" Icon="shield-lock-fill" MaxWidth="600px">
@@ -49,7 +51,12 @@
                                 <td>@act.Message</td>
                                 <td>@act.Strikes</td>
                                 <td>@act.UseGlobalStrikes</td>
-                                <td><button class="v-btn danger" @onclick="(() => RemoveNewAction(act))">Remove</button></td>
+                                <td>
+                                    <div class="button-row">
+                                        <button class="v-btn" @onclick="(() => EditAction(act))">Edit</button>
+                                        <button class="v-btn danger" @onclick="(() => RemoveNewAction(act))">Remove</button>
+                                    </div>
+                                </td>
                             </tr>
                         }
                     </tbody>
@@ -70,6 +77,59 @@
             <button class="v-btn mt-2" @onclick="OnAddAction">Add Action</button>
             <ResultLabel Result="@_result" />
         }
+        else if (_step == 3)
+        {
+            <p class="subtitle">@(_actionIsNew ? "Add Action" : "Edit Action")</p>
+            <div class="form-group mt-2">
+                <label>Type</label>
+                <select class="form-control" @bind="_action.ActionType">
+                    @foreach (AutomodActionType t in Enum.GetValues<AutomodActionType>())
+                    {
+                        <option value="@t">@t</option>
+                    }
+                </select>
+            </div>
+
+            <div class="form-group mt-2">
+                <label>Strikes Required</label>
+                <InputNumber class="form-control" TValue="int" @bind-Value="_action.Strikes" />
+            </div>
+            <div class="form-group mt-2">
+                <label><input type="checkbox" @bind="_action.UseGlobalStrikes" /> Use Global Strikes</label>
+            </div>
+
+            @if (ShowExpires)
+            {
+                <div class="form-group mt-2">
+                    <label>Duration Minutes (0 for permanent)</label>
+                    <InputNumber class="form-control" TValue="int" @bind-Value="_duration" />
+                </div>
+            }
+
+            @if (ShowRole)
+            {
+                <div class="form-group mt-2">
+                    <label>Role</label>
+                    <select class="form-control" @bind="_selectedRoleId">
+                        <option value="0">Select Role</option>
+                        @foreach (var role in Data.Planet.Roles)
+                        {
+                            <option value="@role.Id">@role.Name</option>
+                        }
+                    </select>
+                </div>
+            }
+
+            @if (ShowMessage)
+            {
+                <div class="form-group mt-2">
+                    <label>Message</label>
+                    <textarea class="form-control" @bind="_action.Message"></textarea>
+                </div>
+            }
+
+            <ResultLabel Result="@_actionResult" />
+        }
     </MainArea>
     <ButtonArea>
         <div class="basic-modal-buttons">
@@ -78,13 +138,18 @@
             {
                 <button class="v-btn primary" @onclick="NextStep">Next</button>
             }
-            else
+            else if (_step == 2)
             {
                 <button class="v-btn" @onclick="PrevStep">Back</button>
                 @if (_isNew || _changed)
                 {
                     <button class="v-btn primary" @onclick="OnSave">Save</button>
                 }
+            }
+            else if (_step == 3)
+            {
+                <button class="v-btn" @onclick="CancelAction">Back</button>
+                <button class="v-btn primary" @onclick="OnSaveAction">Save</button>
             }
         </div>
     </ButtonArea>
@@ -148,7 +213,15 @@
     private ModelQueryEngine<AutomodAction> _actionEngine;
     private List<AutomodAction> _newActions;
 
-    private string ModalTitle => $"{(_isNew ? "Add Trigger" : "Edit Trigger")} - Step {_step} of 2";
+    private AutomodAction _action;
+    private bool _actionIsNew;
+    private int _duration;
+    private long _selectedRoleId;
+    private ITaskResult _actionResult;
+
+    private string ModalTitle => _step == 3
+        ? (_actionIsNew ? "Add Action" : "Edit Action")
+        : $"{(_isNew ? "Add Trigger" : "Edit Trigger")} - Step {_step} of 2";
 
     private void NextStep() => _step = Math.Min(2, _step + 1);
 
@@ -208,9 +281,10 @@
             {
                 Name = "Actions",
                 RenderFragment = row => @<div class="button-row">
+                        <button class="v-btn" @onclick="(() => EditAction(row.Row))">Edit</button>
                         <button class="v-btn danger" @onclick="(() => RemoveAction(row.Row))">Remove</button>
                     </div>,
-                Width = "120px"
+                Width = "160px"
             }
         };
     }
@@ -242,24 +316,79 @@
 
     private void OnAddAction()
     {
-        var data = new AutomodActionModal.ModalParams
+        _action = new AutomodAction(Client)
         {
-            Planet = Data.Planet,
-            Trigger = _trigger,
-            Action = null,
-            OnSaved = async () =>
-            {
-                if (_actionTable is not null)
-                    await _actionTable.Requery();
-            },
-            LocalOnly = _isNew,
-            OnSavedAction = async act =>
-            {
-                _newActions.Add(act);
-                StateHasChanged();
-            }
+            PlanetId = Data.Planet.Id,
+            TriggerId = _trigger.Id,
+            Message = string.Empty,
+            Strikes = 1,
+            UseGlobalStrikes = false
         };
-        ModalRoot.OpenModal<Moderation.AutomodActionModal>(data);
+        _duration = 0;
+        _selectedRoleId = 0;
+        _actionIsNew = true;
+        _actionResult = null;
+        _step = 3;
+    }
+
+    private void EditAction(AutomodAction act)
+    {
+        _action = act;
+        _duration = _action.Expires.HasValue ?
+            (int)Math.Ceiling((_action.Expires.Value - DateTime.UtcNow).TotalMinutes) : 0;
+        _selectedRoleId = _action.RoleId ?? 0;
+        _actionIsNew = false;
+        _actionResult = null;
+        _step = 3;
+    }
+
+    private async Task OnSaveAction()
+    {
+        if (ShowRole)
+            _action.RoleId = _selectedRoleId;
+        if (ShowExpires)
+            _action.Expires = _duration > 0 ? DateTime.UtcNow.AddMinutes(_duration) : null;
+
+        TaskResult<AutomodAction> res;
+        if (_actionIsNew)
+        {
+            if (_isNew)
+            {
+                _action.Id = Guid.NewGuid();
+                _newActions.Add(_action);
+                res = TaskResult<AutomodAction>.FromData(_action);
+            }
+            else
+            {
+                res = await Client.AutomodService.CreateActionAsync(_action);
+            }
+        }
+        else
+        {
+            if (_isNew)
+            {
+                res = TaskResult<AutomodAction>.FromData(_action);
+            }
+            else
+            {
+                res = await _action.UpdateAsync();
+            }
+        }
+
+        _actionResult = res;
+        if (res.Success)
+        {
+            if (!_isNew && _actionTable is not null)
+                await _actionTable.Requery();
+
+            _step = 2;
+        }
+    }
+
+    private void CancelAction()
+    {
+        _step = 2;
+        _actionResult = null;
     }
 
     private async Task RemoveAction(AutomodAction action)


### PR DESCRIPTION
## Summary
- rework Automod trigger modal to embed action editing
- replace custom role dropdown with standard select
- adjust existing Automod action modal to match select component

## Testing
- `./dotnet/dotnet test Valour/Valour.sln --no-build` *(fails: The argument ... invalid)*