### PR TITLE
[feature] Assign message member id automatically on planets

### DIFF
--- a/Valour/Server/Api/Dynamic/MessageApi.cs
+++ b/Valour/Server/Api/Dynamic/MessageApi.cs
@@ -65,7 +65,7 @@ public class MessageApi
             if (member is null)
                 return ValourResult.Forbid("You are not a member of the planet this channel belongs to");
 
-            message.AuthorMemberId = member.UserId;
+            message.AuthorMemberId = member.Id;
             
             // NOTE: We don't have to check View permission because lacking view will
             // cause every other permission check to fail

--- a/Valour/Server/Api/Dynamic/MessageApi.cs
+++ b/Valour/Server/Api/Dynamic/MessageApi.cs
@@ -64,6 +64,8 @@ public class MessageApi
             var member = await memberService.GetCurrentAsync(channel.PlanetId.Value);
             if (member is null)
                 return ValourResult.Forbid("You are not a member of the planet this channel belongs to");
+
+            message.AuthorMemberId = member.UserId;
             
             // NOTE: We don't have to check View permission because lacking view will
             // cause every other permission check to fail


### PR DESCRIPTION
Automatically assign `AuthorMemberId` on requests, like the `AuthorUserId` field, to remove the dependency for an extra API call to look up member status before sending messages.