### PR TITLE
Fix the ability to send messages with secret, unrendered text.

### DIFF
--- a/Valour/Server/Services/MessageService.cs
+++ b/Valour/Server/Services/MessageService.cs
@@ -223,7 +223,7 @@ public class MessageService
         {
             // Prevent markdown bypassing inline, e.g. [](https://example.com)
             // This is because a direct image link is not proxied and can steal ip addresses
-            message.Content = message.Content.Replace("[](", "(");
+            message.Content = message.Content.Replace("[](", "[]\\("); // Fix: Insert backslash instead of removing [] because users could simply type [][]()
 	        
             var inlineAttachments = await _proxyHandler.GetUrlAttachmentsFromContent(message.Content, _db);
             if (inlineAttachments is not null)

--- a/Valour/Server/Services/MessageService.cs
+++ b/Valour/Server/Services/MessageService.cs
@@ -224,6 +224,11 @@ public class MessageService
             // Prevent markdown bypassing inline, e.g. [](https://example.com)
             // This is because a direct image link is not proxied and can steal ip addresses
             message.Content = message.Content.Replace("[](", "[]\\("); // Fix: Insert backslash instead of removing [] because users could simply type [][]()
+
+            // Prevent hiding secret messages with markdown
+            // This is because it cannot be revealed with custom css themes, it can only be seen with right click -> copy text.
+            // Nightmare for moderation.
+            message.Content = message.Content.Replace("]()", "]\\()");
 	        
             var inlineAttachments = await _proxyHandler.GetUrlAttachmentsFromContent(message.Content, _db);
             if (inlineAttachments is not null)


### PR DESCRIPTION
Users could send messages with hidden text like \[this](), which would be rendered as an empty string with a link referring to this. Custom css can't be used to reveal this text because the hidden text is in the href attribute rather than the text. It's a nightmare for moderation if members communicate like this since the only way to see it is to use the copy text button.

The fix is to insert a backslash into the message between ] and (). This prevents the text from being rendered as a link with no text, and doesn't appear to have a backslash inserted.

Also, there was a similar replace already present which changes []( to (. The problem with this was that users could just type [][]( and it would be changed to [](.

The fix is to instead replace []( with []\\(. This will appear as [](, but the backslash breaks up the [] and (.