### PR TITLE
Fixed Send, Emoji and Upload icons Alignment & Fixed CopyId Buttons

### DIFF
--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor.css
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor.css
@@ -80,6 +80,7 @@
 .send-wrapper {
     display: flex;
     align-items: center;
+    margin-left: 1px;
 }
 
 .send-button {
@@ -90,7 +91,6 @@
     text-align: center;
     line-height: 24px;
     cursor: pointer;
-    margin-left: 3px;
 }
 
 .send-wrapper:active .send-button {
@@ -99,6 +99,8 @@
 
 .textbox-holder {
     display: flex;
+    align-items: center;
+    gap: 4px;
     width: 100%;
     max-width: 100%;
     overflow: hidden;
@@ -213,7 +215,7 @@
     border: none;
     outline: none;
     filter: grayscale(1);
-    padding-left: 4px;
+    padding: 0;
 }
 
 .emoji-button:hover {

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor.css
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor.css
@@ -80,7 +80,6 @@
 .send-wrapper {
     display: flex;
     align-items: center;
-    margin-left: 1px;
 }
 
 .send-button {
@@ -91,6 +90,7 @@
     text-align: center;
     line-height: 24px;
     cursor: pointer;
+    margin-left: 1px;
 }
 
 .send-wrapper:active .send-button {
@@ -169,8 +169,8 @@
 }
 
 .mobile .upload-menu {
-    bottom: 60px;
-    right: 21px;
+    bottom: 65px;
+    right: 23px;
 }
 
 .upload-menu .content {

--- a/Valour/Client/ContextMenu/Menus/ChannelContextMenu.razor
+++ b/Valour/Client/ContextMenu/Menus/ChannelContextMenu.razor
@@ -72,7 +72,7 @@
     }
     
     private async Task OnClickCopyId(){
-        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Data.Channel.Id);
+        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Data.Channel.Id.ToString());
         ToastContainer.Instance.AddToast(new ToastData("Copied!", "Channel ID copied to clipboard", ToastProgressState.Success));
     }
 

--- a/Valour/Client/ContextMenu/Menus/Member/MemberContextMenu.razor
+++ b/Valour/Client/ContextMenu/Menus/Member/MemberContextMenu.razor
@@ -158,12 +158,12 @@ else if (!_isSelf)
     }
 
     private async Task OnClickCopyMemberId(){
-        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Data.Member.Id);
+        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Data.Member.Id.ToString());
         ToastContainer.Instance.AddToast(new ToastData("Copied!", "Member ID copied to clipboard", ToastProgressState.Success));
     }
 
     private async Task OnClickCopyUserId(){
-        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Data.Member.UserId);
+        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Data.Member.UserId.ToString());
         ToastContainer.Instance.AddToast(new ToastData("Copied!", "User ID copied to clipboard", ToastProgressState.Success));
     }
 

--- a/Valour/Client/ContextMenu/Menus/MessageContextMenu.razor
+++ b/Valour/Client/ContextMenu/Menus/MessageContextMenu.razor
@@ -150,7 +150,7 @@
     }
 
     private async Task OnClickCopyId(){
-        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Data.Message.Id);
+        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Data.Message.Id.ToString());
         ToastContainer.Instance.AddToast(new ToastData("Copied!", "Message ID copied to clipboard", ToastProgressState.Success));
     }
 }

--- a/Valour/Client/ContextMenu/Menus/PlanetContextMenu.razor
+++ b/Valour/Client/ContextMenu/Menus/PlanetContextMenu.razor
@@ -103,7 +103,7 @@
 
     private async Task OnClickCopyId()
     {
-        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Data.Planet.Id);
+        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Data.Planet.Id.ToString());
         ToastContainer.Instance.AddToast(new ToastData("Copied!", "Planet ID copied to clipboard", ToastProgressState.Success));
     }
 

--- a/Valour/Client/ContextMenu/Menus/UserContextMenu.razor
+++ b/Valour/Client/ContextMenu/Menus/UserContextMenu.razor
@@ -115,7 +115,7 @@ else if (!_isSelf)
     }
 
     private async Task OnClickCopyUserId(){
-        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Data.User.Id);
+        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Data.User.Id.ToString());
         ToastContainer.Instance.AddToast(new ToastData("Copied!", "User ID copied to clipboard", ToastProgressState.Success));
     }
 	


### PR DESCRIPTION
Fixed Button Alignment for Send, Emoji and Upload

Before:
<img width="147" height="164" alt="image" src="https://github.com/user-attachments/assets/fa944483-8496-4b99-9fd1-987c256363ba" />


After:
<img width="162" height="186" alt="image" src="https://github.com/user-attachments/assets/6fea873d-8ed2-49de-a4b0-6b6813e94661" />


Also Fixed and Tested the CopyId buttons: Thanks to #1360 
