### PR TITLE
fix: recover missed messages on mobile app resume

### DIFF
--- a/Valour/Client.Maui/Platforms/Android/MainActivity.cs
+++ b/Valour/Client.Maui/Platforms/Android/MainActivity.cs
@@ -43,6 +43,12 @@ public class MainActivity : MauiAppCompatActivity
         AppLifecycle.NotifyResumed();
     }
 
+    protected override void OnPause()
+    {
+        base.OnPause();
+        AppLifecycle.NotifyBackground();
+    }
+
     protected override void OnActivityResult(int requestCode, Result resultCode, Intent? data)
     {
         if (requestCode == AudioPermissionChromeClient.FileChooserRequestCode)

--- a/Valour/Client.Maui/Platforms/MacCatalyst/AppDelegate.cs
+++ b/Valour/Client.Maui/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,4 +1,5 @@
-﻿using Foundation;
+using Foundation;
+using UIKit;
 
 namespace Valour.Client.Maui;
 
@@ -6,4 +7,16 @@ namespace Valour.Client.Maui;
 public class AppDelegate : MauiUIApplicationDelegate
 {
     protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+    public override void DidEnterBackground(UIApplication application)
+    {
+        base.DidEnterBackground(application);
+        AppLifecycle.NotifyBackground();
+    }
+
+    public override void OnActivated(UIApplication application)
+    {
+        base.OnActivated(application);
+        AppLifecycle.NotifyResumed();
+    }
 }

--- a/Valour/Client.Maui/Platforms/iOS/AppDelegate.cs
+++ b/Valour/Client.Maui/Platforms/iOS/AppDelegate.cs
@@ -1,4 +1,5 @@
-﻿using Foundation;
+using Foundation;
+using UIKit;
 
 namespace Valour.Client.Maui;
 
@@ -6,4 +7,16 @@ namespace Valour.Client.Maui;
 public class AppDelegate : MauiUIApplicationDelegate
 {
     protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+    public override void DidEnterBackground(UIApplication application)
+    {
+        base.DidEnterBackground(application);
+        AppLifecycle.NotifyBackground();
+    }
+
+    public override void OnActivated(UIApplication application)
+    {
+        base.OnActivated(application);
+        AppLifecycle.NotifyResumed();
+    }
 }

--- a/Valour/Client/AppLifecycle.cs
+++ b/Valour/Client/AppLifecycle.cs
@@ -7,6 +7,7 @@ namespace Valour.Client;
 public static class AppLifecycle
 {
     public static event Action? Resumed;
+    public static event Action? Backgrounded;
 
     /// <summary>
     /// Fired when a voice call begins. Platform projects can subscribe to start
@@ -20,6 +21,7 @@ public static class AppLifecycle
     public static event Action? CallEnded;
 
     public static void NotifyResumed() => Resumed?.Invoke();
+    public static void NotifyBackground() => Backgrounded?.Invoke();
     public static void NotifyCallStarted() => CallStarted?.Invoke();
     public static void NotifyCallEnded() => CallEnded?.Invoke();
 }

--- a/Valour/Client/Components/Windows/ChannelWindows/ChatWindowComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/ChatWindowComponent.razor
@@ -1,4 +1,4 @@
-﻿@inherits WindowContentComponent<Channel>
+@inherits WindowContentComponent<Channel>
 @implements IAsyncDisposable
 @inject IJSRuntime JsRuntime
 @inject ValourClient Client
@@ -1258,6 +1258,27 @@
     {
         await InvokeAsync(async () =>
         {
+            // Wait for the relevant node to finish reconnecting before we attempt recovery.
+            // On mobile resume, CheckConnections() is fired by BrowserUtils.OnRefocus but
+            // the SignalR reconnection is async. If we recover too early, we'll fetch stale
+            // data and miss messages that arrived during the reconnection gap.
+            var node = Channel?.PlanetId is not null
+                ? Channel.Planet?.Node
+                : Client.PrimaryNode;
+
+            if (node?.IsReconnecting == true)
+            {
+                // Give the reconnect up to 5 seconds before proceeding anyway.
+                for (var i = 0; i < 50 && node.IsReconnecting; i++)
+                    await Task.Delay(100);
+
+                if (node.IsReconnecting)
+                {
+                    Client.Logger.Log<ChatWindowComponent>(
+                        "Node still reconnecting after focus; attempting message recovery anyway.", "yellow");
+                }
+            }
+
             if (Channel?.PlanetId is not null && Channel.ChannelType == ChannelTypeEnum.PlanetChat)
             {
                 try


### PR DESCRIPTION
## Problem

When the mobile app is reopened after being in the background, messages that arrived during the background period were not loading. Users had to manually switch channels or restart the app to see new messages.

## Root Cause

Two issues were identified:

### 1. Missing lifecycle hooks (iOS & MacCatalyst)
The `AppLifecycle.NotifyResumed()` event never fired on iOS or MacCatalyst because neither platform had native lifecycle callbacks wired up. Only Android had `OnResume` → `NotifyResumed()`. Without the `Resumed` event, `BrowserUtils.OnRefocus()` never triggered, and `ChatWindowComponent.OnBrowserFocused()` never ran on those platforms.

Android also lacked a `Backgrounded` notification.

### 2. Race condition on resume
Even on Android where the lifecycle event did fire, there was a race condition. The flow was:
1. `AppLifecycle.NotifyResumed()` → `BrowserUtils.OnRefocus()` → `NodeService.CheckConnections()` + `Focused.Invoke()`
2. `ChatWindowComponent.OnBrowserFocused()` → `RecoverMissedMessages()` immediately

`CheckConnections()` kicks off an async SignalR reconnection, but `RecoverMissedMessages()` runs immediately after without waiting for the reconnection to complete. The recovery API call could return before the server re-joins the channel, causing it to miss messages that arrived during the reconnection gap.

## Changes

- **iOS `AppDelegate`**: Add `OnActivated` → `NotifyResumed()` and `DidEnterBackground` → `NotifyBackground()`
- **MacCatalyst `AppDelegate`**: Same lifecycle hooks as iOS
- **Android `MainActivity`**: Add `OnPause` → `NotifyBackground()`
- **`AppLifecycle`**: Add `Backgrounded` event and `NotifyBackground()` method
- **`ChatWindowComponent.OnBrowserFocused()`**: Wait up to 5 seconds for the relevant node to finish reconnecting before calling `RecoverMissedMessages()`. If the reconnect takes longer, log a warning and proceed anyway.

## Testing

- Build succeeds with 0 errors
- Android: `OnResume`/`OnPause` lifecycle hooks verified
- iOS: `OnActivated`/`DidEnterBackground` hooks added (matching standard Xamarin/MAUI patterns)
- MacCatalyst: Same as iOS

## Files Changed

- `Valour/Client.Maui/Platforms/Android/MainActivity.cs`
- `Valour/Client.Maui/Platforms/iOS/AppDelegate.cs`
- `Valour/Client.Maui/Platforms/MacCatalyst/AppDelegate.cs`
- `Valour/Client/AppLifecycle.cs`
- `Valour/Client/Components/Windows/ChannelWindows/ChatWindowComponent.razor`