### PR TITLE
fix: FK violation when replying to deleted message (fk_replyto)

### DIFF
--- a/Valour/Server/Workers/PlanetMessageWorker.cs
+++ b/Valour/Server/Workers/PlanetMessageWorker.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 
 namespace Valour.Server.Workers
 {
@@ -215,8 +215,17 @@ namespace Valour.Server.Workers
                 
                 if (message.ReplyToId is not null && message.ReplyTo is null)
                 {
-                    var replyTo = (await dbService.Messages.FindAsync(message.ReplyToId)).ToModel();
-                    message.ReplyTo = replyTo;
+                    var replyToDb = await dbService.Messages.FindAsync(message.ReplyToId);
+                    if (replyToDb is not null)
+                    {
+                        message.ReplyTo = replyToDb.ToModel();
+                    }
+                    else
+                    {
+                        // The referenced reply-to message no longer exists (deleted).
+                        // Clear ReplyToId to avoid FK constraint violation (fk_replyto) on insert.
+                        message.ReplyToId = null;
+                    }
                 }
                 
                 hubService.RelayMessage(message);


### PR DESCRIPTION
When a message references a ReplyToId for a message that has been deleted, the insert into the messages table violates the fk_replyto foreign key constraint. This commonly happens when messages are deleted between the time a user sends a reply and when the PlanetMessageWorker flushes to DB.

Fix: If the reply-to message is not found in the database, clear the ReplyToId to avoid the FK violation. The message will still be delivered but won't link to the deleted parent.

Also fixes a secondary NullReferenceException where .ToModel() was called on a potentially null result.

Fixes VALOUR-BACKEND-3T (159 events, 45 users affected)