### PR TITLE
fix: Stripe exception 'This property cannot be expanded (metadata)'

### DIFF
--- a/Valour/Server/Workers/StripeReconciliationWorker.cs
+++ b/Valour/Server/Workers/StripeReconciliationWorker.cs
@@ -57,11 +57,9 @@ public class StripeReconciliationWorker : IHostedService, IDisposable
             {
                 try
                 {
-                    // Need to expand metadata since list doesn't include it by default
-                    var fullSession = await service.GetAsync(session.Id, new SessionGetOptions
-                    {
-                        Expand = new List<string> { "metadata" }
-                    });
+                    // Metadata is always included in the response; it doesn't need expanding.
+                    // Previously tried to expand "metadata" which caused a StripeException.
+                    var fullSession = await service.GetAsync(session.Id);
 
                     if (fullSession.Mode == "subscription")
                         await Valour.Server.Api.Dynamic.StripeApi.FulfillSubscriptionSessionAsync(fullSession, ecoService, db, _logger);


### PR DESCRIPTION
The StripeReconciliationWorker was trying to expand the 'metadata' property when fetching session details, but metadata is a hash map that is always included in the response — it's not an expandable sub-resource. This caused a StripeException on every reconciliation run.

Fix: Remove the Expand option and just fetch the session directly. Metadata will be included automatically.

Fixes VALOUR-BACKEND-6W (216 events, 13 users affected)