### PR TITLE
fix: DbUpdateConcurrencyException when expiring auth tokens

### DIFF
--- a/Valour/Server/Services/TokenService.cs
+++ b/Valour/Server/Services/TokenService.cs
@@ -57,12 +57,14 @@ public class TokenService
         {
             // Remove expired token from cache and database
             QuickCache.Remove(key, out _);
-            var dbToken = await _db.AuthTokens.FindAsync(key);
-            if (dbToken is not null)
-            {
-                _db.AuthTokens.Remove(dbToken);
-                await _db.SaveChangesAsync();
-            }
+            
+            // Use ExecuteDeleteAsync instead of Remove+SaveChangesAsync to avoid
+            // DbUpdateConcurrencyException when multiple requests try to expire
+            // the same token concurrently.
+            await _db.AuthTokens.IgnoreQueryFilters()
+                .Where(x => x.Id == key)
+                .ExecuteDeleteAsync();
+            
             return null;
         }
 


### PR DESCRIPTION
When multiple concurrent requests check the same expired token, they can all try to delete it from the database simultaneously. Using EF Core's Remove + SaveChangesAsync causes a DbUpdateConcurrencyException because the change tracker expects the entity to still exist.

Fix: Use ExecuteDeleteAsync which issues a direct SQL DELETE statement, avoiding the change tracker entirely. This is idempotent — if the row is already gone, it simply affects 0 rows without throwing.

Fixes VALOUR-BACKEND-6M (17 events, 7 users affected)