### PR TITLE
fix: prevent double-submit on upload and handle DB race on cdn insert

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor
@@ -40,7 +40,7 @@
     <ButtonArea>
         <div class="basic-modal-buttons">
             <button @onclick="@OnClickCancel" class="v-btn">Cancel</button>
-            <button @onclick="@OnClickConfirm" class="v-btn primary">Upload</button>
+            <button @onclick="@OnClickConfirm" class="v-btn primary" disabled="@_isUploading">Upload</button>
         </div>
     </ButtonArea>
 </BasicModalLayout>
@@ -59,6 +59,7 @@
 
     private bool _imageReady;
     private bool _loaded = false;
+    private bool _isUploading = false;
 
     protected override async Task OnInitializedAsync(){
 
@@ -102,6 +103,8 @@
     public void OnClickCancel() => Close();
 
     public async Task OnClickConfirm(){
+        if (_isUploading) return;
+        _isUploading = true;
         await Data.OnConfirm.Invoke();
         Close();
     }

--- a/Valour/Server/Cdn/CdnBucketService.cs
+++ b/Valour/Server/Cdn/CdnBucketService.cs
@@ -1,8 +1,9 @@
-﻿using Amazon.S3;
+using Amazon.S3;
 using Amazon.S3.Model;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore;
 using CloudFlare.Client;
 using CloudFlare.Client.Api.Zones;
 using Valour.Config.Configs;
@@ -169,11 +170,22 @@ public class CdnBucketService
                 await db.CdnBucketItems.AddAsync(bucketRecord);
                 await db.SaveChangesAsync();
             }
-            catch (Exception e)
+            catch (DbUpdateException)
             {
+                // Race condition: another request inserted this row between our AnyAsync check and SaveChangesAsync.
+                // Detach the failed entity so the DbContext isn't corrupted for any future operations.
+                var entry = db.Entry(bucketRecord);
+                if (entry.State == EntityState.Added)
+                    entry.State = EntityState.Detached;
+
                 if (await db.CdnBucketItems.AnyAsync(x => x.Id == id))
                     return new TaskResult(true, $"https://cdn.valour.gg/content/{id}");
 
+                _logger.LogError("DbUpdateException when adding new route to existing bucket item, and row still not found for {Id}", id);
+                return new TaskResult(false, "Critical error when adding new route to existing bucket item.");
+            }
+            catch (Exception e)
+            {
                 _logger.LogError(e, "Critical error when adding new route to existing bucket item");
                 return new TaskResult(false, "Critical error when adding new route to existing bucket item.");
             }
@@ -192,11 +204,22 @@ public class CdnBucketService
             await db.CdnBucketItems.AddAsync(bucketRecord);
             await db.SaveChangesAsync();
         }
-        catch (Exception e)
+        catch (DbUpdateException)
         {
+            // Race condition: another request inserted this row between our AnyAsync check and SaveChangesAsync.
+            // Detach the failed entity so the DbContext isn't corrupted for any future operations.
+            var entry = db.Entry(bucketRecord);
+            if (entry.State == EntityState.Added)
+                entry.State = EntityState.Detached;
+
             if (await db.CdnBucketItems.AnyAsync(x => x.Id == id))
                 return new TaskResult(true, $"https://cdn.valour.gg/content/{id}");
 
+            _logger.LogError("DbUpdateException when adding route to new bucket item, and row still not found for {Id}", id);
+            return new TaskResult(false, "Critical error when adding route to new bucket item.");
+        }
+        catch (Exception e)
+        {
             _logger.LogError(e, "Critical error when adding route to new bucket item");
             return new TaskResult(false, "Critical error when adding route to new bucket item.");
         }


### PR DESCRIPTION
Two related fixes for the upload flow:

**1. Client: FileUploadComponent double-submit guard**
The Upload button and Enter key had no guard against double-firing. Added `_isUploading` flag that blocks repeated clicks and disables the button during upload.

**2. Server: CdnBucketService race condition handling**
The check-then-insert pattern (AnyAsync → AddAsync → SaveChangesAsync) has a TOCTOU race under concurrent uploads. Both requests pass the AnyAsync check, both try to insert, one gets a DbUpdateException on the PK. The old code caught generic Exception and logged it as an error even though it was a harmless duplicate.

Changes:
- Catch DbUpdateException specifically before the generic Exception handler
- Detach the failed entity from the DbContext so it doesn't corrupt future operations
- Only log as error if the row still doesn't exist after the race (genuinely unexpected)
- Generic Exception catch remains as a safety net for actual failures

This should eliminate the Sentry alerts for VALOUR-BACKEND-2B (Failed DbCommand INSERT into cdn_bucket_items) while keeping the upload flow working correctly.