### PR TITLE
fix: upload double-submit, DB race, and add real progress tracking

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor
@@ -1,5 +1,6 @@
 @inherits Modal<FileUploadComponent.ModalParams>
 @inject IJSRuntime JsRuntime
+@inject UploadService UploadSvc
 @implements IDisposable
 
 @if (Data.Attachment is null)
@@ -39,11 +40,11 @@
         @if (_isUploading)
         {
             <div class="upload-progress-container">
-                <div class="upload-progress-bar" style="width: @(_uploadProgress)%"></div>
+                <div class="upload-progress-bar" style="width: @(_progress?.Percent ?? 0)%"></div>
             </div>
             <div class="upload-progress-info">
-                <span class="upload-progress-text">@_uploadProgress%</span>
-                <span class="upload-progress-bytes">@(FormatBytes(_uploadedBytes)) / @(FormatBytes(_totalBytes))</span>
+                <span class="upload-progress-text">@(_progress?.Percent ?? 0)%</span>
+                <span class="upload-progress-bytes">@(_progress?.FormattedUploaded ?? "0 B") / @(_progress?.FormattedTotal ?? "0 B")</span>
             </div>
         }
         @if (_uploadError is not null)
@@ -84,10 +85,10 @@
     private bool _imageReady;
     private bool _loaded = false;
     private bool _isUploading = false;
-    private int _uploadProgress;
-    private long _uploadedBytes;
-    private long _totalBytes;
+    private UploadProgressInfo? _progress;
     private string _uploadError;
+
+    private CancellationTokenSource? _uploadCts;
 
     protected override async Task OnInitializedAsync()
     {
@@ -123,51 +124,6 @@
         StateHasChanged();
     }
 
-    [JSInvokable]
-    public void OnUploadProgress(long loaded, long total)
-    {
-        _uploadedBytes = loaded;
-        _totalBytes = total;
-        _uploadProgress = total > 0 ? (int)Math.Round((double)loaded / total * 100) : 0;
-        StateHasChanged();
-    }
-
-    [JSInvokable]
-    public void OnUploadComplete(string response)
-    {
-        _isUploading = false;
-        _uploadProgress = 100;
-        
-        Data.OnUploadSuccess?.Invoke(response);
-        
-        StateHasChanged();
-        Close();
-    }
-
-    [JSInvokable]
-    public void OnUploadMisdirect(string responseBody, int statusCode)
-    {
-        _isUploading = false;
-        _uploadError = $"Server redirect ({statusCode}). Please try again.";
-        StateHasChanged();
-    }
-
-    [JSInvokable]
-    public void OnUploadError(string error)
-    {
-        _isUploading = false;
-        _uploadError = error;
-        StateHasChanged();
-    }
-
-    [JSInvokable]
-    public void OnUploadCancelled()
-    {
-        _isUploading = false;
-        _uploadProgress = 0;
-        StateHasChanged();
-    }
-
     public async Task OnKeyDown(KeyboardEventArgs e)
     {
         if (e.Key.ToLower() == "enter" && !_isUploading)
@@ -176,40 +132,52 @@
 
     public void OnClickCancel() => Close();
 
-    public async Task OnClickCancelUpload()
+    public void OnClickCancelUpload()
     {
-        await JsRuntime.InvokeVoidAsync("abortCurrentUpload");
+        _uploadCts?.Cancel();
     }
 
     public async Task OnClickConfirm()
     {
         if (_isUploading) return;
         
-        // If we have the new upload path, use JS progress upload
+        // New path: use UploadService for real progress
         if (!string.IsNullOrEmpty(Data.UploadUrl))
         {
             _isUploading = true;
-            _uploadProgress = 0;
-            _uploadedBytes = 0;
+            _progress = null;
             _uploadError = null;
+            _uploadCts = new CancellationTokenSource();
             StateHasChanged();
 
-            try
+            var result = await UploadSvc.UploadAsync(
+                Data.UploadUrl,
+                Data.Bytes,
+                Data.Attachment.MimeType,
+                Data.Attachment.FileName,
+                Data.AuthToken,
+                onProgress: p =>
+                {
+                    _progress = p;
+                    InvokeAsync(StateHasChanged);
+                },
+                cancellationToken: _uploadCts.Token);
+
+            _isUploading = false;
+            _uploadCts.Dispose();
+            _uploadCts = null;
+
+            if (result.Success)
             {
-                await JsRuntime.InvokeVoidAsync("uploadWithProgress",
-                    Data.UploadUrl,
-                    Data.Bytes,
-                    Data.Attachment.MimeType,
-                    Data.Attachment.FileName,
-                    _thisRef,
-                    Data.AuthToken);
+                Data.OnUploadSuccess?.Invoke(result.Response);
+                Close();
             }
-            catch (Exception ex)
+            else
             {
-                _isUploading = false;
-                _uploadError = ex.Message;
-                StateHasChanged();
+                _uploadError = result.Error ?? "Unknown error";
             }
+
+            StateHasChanged();
         }
         else
         {
@@ -220,15 +188,10 @@
         }
     }
 
-    private static string FormatBytes(long bytes)
-    {
-        if (bytes < 1024) return $"{bytes} B";
-        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
-        return $"{bytes / (1024.0 * 1024.0):F1} MB";
-    }
-
     public void Dispose()
     {
+        _uploadCts?.Cancel();
+        _uploadCts?.Dispose();
         _thisRef?.Dispose();
     }
 }

--- a/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor
@@ -36,11 +36,32 @@
                 }
             }
         </div>
+        @if (_isUploading)
+        {
+            <div class="upload-progress-container">
+                <div class="upload-progress-bar" style="width: @(_uploadProgress)%"></div>
+            </div>
+            <div class="upload-progress-info">
+                <span class="upload-progress-text">@_uploadProgress%</span>
+                <span class="upload-progress-bytes">@(FormatBytes(_uploadedBytes)) / @(FormatBytes(_totalBytes))</span>
+            </div>
+        }
+        @if (_uploadError is not null)
+        {
+            <div class="upload-error">Upload failed: @_uploadError</div>
+        }
     </MainArea>
     <ButtonArea>
         <div class="basic-modal-buttons">
-            <button @onclick="@OnClickCancel" class="v-btn">Cancel</button>
-            <button @onclick="@OnClickConfirm" class="v-btn primary" disabled="@_isUploading">Upload</button>
+            @if (_isUploading)
+            {
+                <button @onclick="@OnClickCancelUpload" class="v-btn danger">Cancel Upload</button>
+            }
+            else
+            {
+                <button @onclick="@OnClickCancel" class="v-btn">Cancel</button>
+                <button @onclick="@OnClickConfirm" class="v-btn primary">Upload</button>
+            }
         </div>
     </ButtonArea>
 </BasicModalLayout>
@@ -53,6 +74,9 @@
         public Func<Task> OnConfirm;
         public Message Message;
         public MessageAttachment Attachment;
+        public string UploadUrl { get; set; }
+        public string AuthToken { get; set; }
+        public Action<string> OnUploadSuccess { get; set; }
     }
 
     private DotNetObjectReference<FileUploadComponent> _thisRef;
@@ -60,9 +84,13 @@
     private bool _imageReady;
     private bool _loaded = false;
     private bool _isUploading = false;
+    private int _uploadProgress;
+    private long _uploadedBytes;
+    private long _totalBytes;
+    private string _uploadError;
 
-    protected override async Task OnInitializedAsync(){
-
+    protected override async Task OnInitializedAsync()
+    {
         Console.WriteLine(JsonSerializer.Serialize(Data.Attachment));
         
         _thisRef = DotNetObjectReference.Create(this);
@@ -95,18 +123,108 @@
         StateHasChanged();
     }
 
-    public async Task OnKeyDown(KeyboardEventArgs e){
-        if (e.Key.ToLower() == "enter")
+    [JSInvokable]
+    public void OnUploadProgress(long loaded, long total)
+    {
+        _uploadedBytes = loaded;
+        _totalBytes = total;
+        _uploadProgress = total > 0 ? (int)Math.Round((double)loaded / total * 100) : 0;
+        StateHasChanged();
+    }
+
+    [JSInvokable]
+    public void OnUploadComplete(string response)
+    {
+        _isUploading = false;
+        _uploadProgress = 100;
+        
+        Data.OnUploadSuccess?.Invoke(response);
+        
+        StateHasChanged();
+        Close();
+    }
+
+    [JSInvokable]
+    public void OnUploadMisdirect(string responseBody, int statusCode)
+    {
+        _isUploading = false;
+        _uploadError = $"Server redirect ({statusCode}). Please try again.";
+        StateHasChanged();
+    }
+
+    [JSInvokable]
+    public void OnUploadError(string error)
+    {
+        _isUploading = false;
+        _uploadError = error;
+        StateHasChanged();
+    }
+
+    [JSInvokable]
+    public void OnUploadCancelled()
+    {
+        _isUploading = false;
+        _uploadProgress = 0;
+        StateHasChanged();
+    }
+
+    public async Task OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key.ToLower() == "enter" && !_isUploading)
             await OnClickConfirm();
     }
 
     public void OnClickCancel() => Close();
 
-    public async Task OnClickConfirm(){
+    public async Task OnClickCancelUpload()
+    {
+        await JsRuntime.InvokeVoidAsync("abortCurrentUpload");
+    }
+
+    public async Task OnClickConfirm()
+    {
         if (_isUploading) return;
-        _isUploading = true;
-        await Data.OnConfirm.Invoke();
-        Close();
+        
+        // If we have the new upload path, use JS progress upload
+        if (!string.IsNullOrEmpty(Data.UploadUrl))
+        {
+            _isUploading = true;
+            _uploadProgress = 0;
+            _uploadedBytes = 0;
+            _uploadError = null;
+            StateHasChanged();
+
+            try
+            {
+                await JsRuntime.InvokeVoidAsync("uploadWithProgress",
+                    Data.UploadUrl,
+                    Data.Bytes,
+                    Data.Attachment.MimeType,
+                    Data.Attachment.FileName,
+                    _thisRef,
+                    Data.AuthToken);
+            }
+            catch (Exception ex)
+            {
+                _isUploading = false;
+                _uploadError = ex.Message;
+                StateHasChanged();
+            }
+        }
+        else
+        {
+            // Fallback: old method without progress
+            _isUploading = true;
+            await Data.OnConfirm.Invoke();
+            Close();
+        }
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        return $"{bytes / (1024.0 * 1024.0):F1} MB";
     }
 
     public void Dispose()

--- a/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor.css
+++ b/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor.css
@@ -42,3 +42,54 @@
     margin-top: 10px;
     margin-bottom: 10px;
 }
+
+.upload-progress-container {
+    width: 100%;
+    height: 8px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-top: 12px;
+}
+
+.upload-progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, #5865F2, #EB459E);
+    border-radius: 4px;
+    transition: width 0.2s ease;
+}
+
+.upload-progress-info {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 6px;
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.upload-progress-text {
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.upload-progress-bytes {
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.upload-error {
+    color: #ED4245;
+    font-size: 13px;
+    margin-top: 8px;
+    padding: 8px;
+    background: rgba(237, 66, 69, 0.1);
+    border-radius: 6px;
+}
+
+::deep .v-btn.danger {
+    background: #ED4245;
+    color: white;
+}
+
+::deep .v-btn.danger:hover {
+    background: #c03537;
+}

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
@@ -1,4 +1,4 @@
-﻿@inject IJSRuntime JsRuntime
+@inject IJSRuntime JsRuntime
 @implements IAsyncDisposable
 @inject ValourClient Client
 
@@ -537,16 +537,6 @@
         // Convert stream to byte array
         var bytes = new byte[data.Length];
         _ = await data.ReadAsync(bytes, 0, bytes.Length);
-        
-        var content = new MultipartFormDataContent();
-        
-        var byteContent = new ByteArrayContent(bytes);
-        if (!string.IsNullOrWhiteSpace(mime))
-        {
-            byteContent.Headers.ContentType = new MediaTypeHeaderValue(mime);
-        }
-
-        content.Add(byteContent, name, name);
 
         MessageAttachment newAttachment = new(type)
         {
@@ -555,13 +545,32 @@
             FileName = name,
         };
 
+        var uploadUrl = Client.BaseAddress + $"upload/{path}";
+        var authToken = Client.AuthService.Token;
+
         var modalData = new FileUploadComponent.ModalParams()
         {
             Bytes = bytes,
             Attachment = newAttachment,
             Message = PreviewMessage,
+            UploadUrl = uploadUrl,
+            AuthToken = authToken,
+            OnUploadSuccess = (location) =>
+            {
+                newAttachment.Location = location;
+                AddMessageAttachment(newAttachment);
+            },
             OnConfirm = async () =>
             {
+                // Fallback for old upload path (no progress)
+                var content = new MultipartFormDataContent();
+                var byteContent = new ByteArrayContent(bytes);
+                if (!string.IsNullOrWhiteSpace(mime))
+                {
+                    byteContent.Headers.ContentType = new MediaTypeHeaderValue(mime);
+                }
+                content.Add(byteContent, name, name);
+
                 var result = await Client.PrimaryNode.PostMultipartDataWithResponse<string>($"upload/{path}", content);
 
                 if (result.Success)

--- a/Valour/Client/ServiceCollectionExtensions.cs
+++ b/Valour/Client/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Valour.Client.Components.Calls;
 using Valour.Client.Components.Sidebar.Directory;
 using Valour.Client.ContextMenu;
 using Valour.Client.Sounds;
+using Valour.Client.Utility;
 using Valour.Sdk.Client;
 using Valour.Sdk.Services;
 
@@ -34,6 +35,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<RealtimeKitHostService>();
         services.AddScoped<GlobalCallSessionService>();
         services.AddScoped<RealtimeKitDeviceService>();
+        services.AddScoped<UploadService>();
 
         // new services
         services.AddSingleton(client);

--- a/Valour/Client/Utility/UploadService.cs
+++ b/Valour/Client/Utility/UploadService.cs
@@ -1,0 +1,190 @@
+using Microsoft.JSInterop;
+using Valour.Shared.Utilities;
+
+namespace Valour.Client.Utility;
+
+/// <summary>
+/// Reusable upload service for Blazor WASM that provides real wire-level
+/// progress tracking and cancellation via XHR. Wrap all your uploads in this
+/// and you never have to touch JS interop again.
+/// </summary>
+public class UploadService : IAsyncDisposable
+{
+    private readonly IJSRuntime _js;
+    private IJSObjectReference? _module;
+    private IJSObjectReference? _currentUpload;
+    private DotNetObjectReference<UploadCallbacks>? _currentDotnetRef;
+    private CancellationTokenSource? _cts;
+
+    public UploadService(IJSRuntime jsRuntime)
+    {
+        _js = jsRuntime;
+    }
+
+    /// <summary>
+    /// Upload a file with real progress tracking. Returns an UploadResult
+    /// when the upload completes (success or failure).
+    /// Cancel via the CancellationToken.
+    /// </summary>
+    public async Task<UploadResult> UploadAsync(
+        string url,
+        byte[] data,
+        string mimeType,
+        string fileName,
+        string? authToken = null,
+        Action<UploadProgressInfo>? onProgress = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Lazy-load the JS module on first use
+        _module ??= await _js.InvokeAsync<IJSObjectReference>("import", "./ts/UploadService.js");
+
+        // If there's a previous upload running, cancel it
+        CancelCurrent();
+
+        var tcs = new TaskCompletionSource<UploadResult>();
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var callbacks = new UploadCallbacks(tcs, onProgress);
+        _currentDotnetRef = DotNetObjectReference.Create(callbacks);
+
+        _currentUpload = await _module.InvokeAsync<IJSObjectReference>(
+            "start",
+            url,
+            data,
+            mimeType,
+            fileName,
+            _currentDotnetRef,
+            authToken);
+
+        // Wire up cancellation
+        _cts.Token.Register(() =>
+        {
+            CancelCurrent();
+            if (!tcs.Task.IsCompleted)
+                tcs.TrySetResult(new UploadResult(false, null, "Upload cancelled"));
+        });
+
+        // Also handle the case where someone cancels the token before we even wire it
+        if (cancellationToken.IsCancellationRequested)
+        {
+            CancelCurrent();
+            return new UploadResult(false, null, "Upload cancelled");
+        }
+
+        return await tcs.Task;
+    }
+
+    /// <summary>
+    /// Cancel whatever upload is currently in flight.
+    /// </summary>
+    public void CancelCurrent()
+    {
+        try
+        {
+            _currentUpload?.InvokeVoidAsync("abort").AsTask().Wait(TimeSpan.FromSeconds(2));
+        }
+        catch
+        {
+            // Best effort - if abort fails the upload will complete or error on its own
+        }
+
+        _currentUpload = null;
+        CleanupDotnetRef();
+    }
+
+    private void CleanupDotnetRef()
+    {
+        _currentDotnetRef?.Dispose();
+        _currentDotnetRef = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        CancelCurrent();
+        _cts?.Cancel();
+        _cts?.Dispose();
+
+        try
+        {
+            if (_module is not null)
+                await _module.DisposeAsync();
+        }
+        catch (JSDisconnectedException) { }
+        catch (JSException) { }
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Internal callback target for JSInvokable calls from the JS module.
+    /// Bridges XHR events into the TaskCompletionSource and progress callback.
+    /// </summary>
+    private sealed class UploadCallbacks
+    {
+        private readonly TaskCompletionSource<UploadResult> _tcs;
+        private readonly Action<UploadProgressInfo>? _onProgress;
+
+        public UploadCallbacks(TaskCompletionSource<UploadResult> tcs, Action<UploadProgressInfo>? onProgress)
+        {
+            _tcs = tcs;
+            _onProgress = onProgress;
+        }
+
+        [JSInvokable("NotifyUploadProgress")]
+        public void NotifyUploadProgress(long loaded, long total)
+        {
+            _onProgress?.Invoke(new UploadProgressInfo(loaded, total));
+        }
+
+        [JSInvokable("NotifyUploadComplete")]
+        public void NotifyUploadComplete(string response)
+        {
+            _tcs.TrySetResult(new UploadResult(true, response, null));
+        }
+
+        [JSInvokable("NotifyUploadMisdirect")]
+        public void NotifyUploadMisdirect(string responseBody, int statusCode)
+        {
+            _tcs.TrySetResult(new UploadResult(false, null, $"Server redirect ({statusCode}). Please try again."));
+        }
+
+        [JSInvokable("NotifyUploadError")]
+        public void NotifyUploadError(string error)
+        {
+            _tcs.TrySetResult(new UploadResult(false, null, error));
+        }
+
+        [JSInvokable("NotifyUploadCancelled")]
+        public void NotifyUploadCancelled()
+        {
+            _tcs.TrySetResult(new UploadResult(false, null, "Upload cancelled"));
+        }
+    }
+}
+
+/// <summary>
+/// The result of an upload operation. Clean and simple.
+/// </summary>
+public record UploadResult(bool Success, string? Response, string? Error)
+{
+    public bool IsMisdirect => !Success && Error?.Contains("redirect") == true;
+}
+
+/// <summary>
+/// Real-time progress info from the XHR upload progress event.
+/// BytesUploaded / TotalBytes are the real wire-level numbers.
+/// </summary>
+public record UploadProgressInfo(long BytesUploaded, long TotalBytes)
+{
+    public int Percent => TotalBytes > 0 ? (int)Math.Round((double)BytesUploaded / TotalBytes * 100) : 0;
+
+    public string FormattedUploaded => FormatBytes(BytesUploaded);
+    public string FormattedTotal => FormatBytes(TotalBytes);
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        return $"{bytes / (1024.0 * 1024.0):F1} MB";
+    }
+}

--- a/Valour/Client/wwwroot/js/main.js
+++ b/Valour/Client/wwwroot/js/main.js
@@ -1,4 +1,4 @@
-﻿document.addEventListener('contextmenu', event => event.preventDefault());
+document.addEventListener('contextmenu', event => event.preventDefault());
 
 window.clipboardCopy = {
     copyText: function (text) {
@@ -282,6 +282,66 @@ function getImageSize(blobUrl, ref) {
         ref.invokeMethodAsync('SetImageSize', this.width, this.height);
     }
     image.src = blobUrl;
+}
+
+// Upload with progress tracking using XMLHttpRequest
+// Called from .NET with: uploadWithProgress(url, byteArray, mimeType, fileName, dotnetRef, authToken)
+function uploadWithProgress(url, byteArray, mimeType, fileName, dotnetRef, authToken) {
+    return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+
+        xhr.upload.addEventListener('progress', (e) => {
+            if (e.lengthComputable) {
+                dotnetRef.invokeMethodAsync('OnUploadProgress', e.loaded, e.total);
+            }
+        });
+
+        xhr.addEventListener('load', () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                dotnetRef.invokeMethodAsync('OnUploadComplete', xhr.responseText);
+                resolve(xhr.responseText);
+            } else if (xhr.status === 421) {
+                dotnetRef.invokeMethodAsync('OnUploadMisdirect', xhr.responseText, xhr.status);
+                resolve(null);
+            } else {
+                dotnetRef.invokeMethodAsync('OnUploadError', `${xhr.status}: ${xhr.responseText}`);
+                reject(new Error(`${xhr.status}: ${xhr.responseText}`));
+            }
+        });
+
+        xhr.addEventListener('error', () => {
+            dotnetRef.invokeMethodAsync('OnUploadError', 'Network error during upload');
+            reject(new Error('Network error during upload'));
+        });
+
+        xhr.addEventListener('abort', () => {
+            dotnetRef.invokeMethodAsync('OnUploadCancelled');
+            reject(new Error('Upload cancelled'));
+        });
+
+        xhr.open('POST', url);
+
+        if (authToken) {
+            xhr.setRequestHeader('Authorization', authToken);
+        }
+
+        // Build FormData from the byte array
+        const blob = new Blob([byteArray], { type: mimeType || 'application/octet-stream' });
+        const formData = new FormData();
+        formData.append(fileName || 'file', blob, fileName || 'file');
+
+        xhr.send(formData);
+
+        // Store abort function so .NET can cancel
+        window._currentUploadAbort = () => xhr.abort();
+    });
+}
+
+function abortCurrentUpload() {
+    if (window._currentUploadAbort) {
+        window._currentUploadAbort();
+        window._currentUploadAbort = null;
+    }
 }
 
 /* Useful functions for layout items */

--- a/Valour/Client/wwwroot/js/main.js
+++ b/Valour/Client/wwwroot/js/main.js
@@ -284,66 +284,6 @@ function getImageSize(blobUrl, ref) {
     image.src = blobUrl;
 }
 
-// Upload with progress tracking using XMLHttpRequest
-// Called from .NET with: uploadWithProgress(url, byteArray, mimeType, fileName, dotnetRef, authToken)
-function uploadWithProgress(url, byteArray, mimeType, fileName, dotnetRef, authToken) {
-    return new Promise((resolve, reject) => {
-        const xhr = new XMLHttpRequest();
-
-        xhr.upload.addEventListener('progress', (e) => {
-            if (e.lengthComputable) {
-                dotnetRef.invokeMethodAsync('OnUploadProgress', e.loaded, e.total);
-            }
-        });
-
-        xhr.addEventListener('load', () => {
-            if (xhr.status >= 200 && xhr.status < 300) {
-                dotnetRef.invokeMethodAsync('OnUploadComplete', xhr.responseText);
-                resolve(xhr.responseText);
-            } else if (xhr.status === 421) {
-                dotnetRef.invokeMethodAsync('OnUploadMisdirect', xhr.responseText, xhr.status);
-                resolve(null);
-            } else {
-                dotnetRef.invokeMethodAsync('OnUploadError', `${xhr.status}: ${xhr.responseText}`);
-                reject(new Error(`${xhr.status}: ${xhr.responseText}`));
-            }
-        });
-
-        xhr.addEventListener('error', () => {
-            dotnetRef.invokeMethodAsync('OnUploadError', 'Network error during upload');
-            reject(new Error('Network error during upload'));
-        });
-
-        xhr.addEventListener('abort', () => {
-            dotnetRef.invokeMethodAsync('OnUploadCancelled');
-            reject(new Error('Upload cancelled'));
-        });
-
-        xhr.open('POST', url);
-
-        if (authToken) {
-            xhr.setRequestHeader('Authorization', authToken);
-        }
-
-        // Build FormData from the byte array
-        const blob = new Blob([byteArray], { type: mimeType || 'application/octet-stream' });
-        const formData = new FormData();
-        formData.append(fileName || 'file', blob, fileName || 'file');
-
-        xhr.send(formData);
-
-        // Store abort function so .NET can cancel
-        window._currentUploadAbort = () => xhr.abort();
-    });
-}
-
-function abortCurrentUpload() {
-    if (window._currentUploadAbort) {
-        window._currentUploadAbort();
-        window._currentUploadAbort = null;
-    }
-}
-
 /* Useful functions for layout items */
 function determineFlip(elementId, safeWidth){
     const element = document.getElementById(elementId);

--- a/Valour/Client/wwwroot/ts/UploadService.js
+++ b/Valour/Client/wwwroot/ts/UploadService.js
@@ -1,0 +1,60 @@
+/**
+ * UploadService JS module
+ * Provides real XHR upload progress + cancel support for Blazor WASM.
+ * Each call to start() returns an upload handle with its own XHR and abort function.
+ */
+
+/**
+ * @param {string} url - Upload endpoint
+ * @param {Uint8Array} byteArray - File data
+ * @param {string} mimeType - MIME type
+ * @param {string} fileName - File name
+ * @param {object} dotnetRef - DotNetObjectReference for callbacks
+ * @param {string} authToken - Optional Authorization header value
+ * @returns {object} Upload handle with an abort() method
+ */
+export function start(url, byteArray, mimeType, fileName, dotnetRef, authToken) {
+    const xhr = new XMLHttpRequest();
+
+    const handle = {
+        abort: () => xhr.abort()
+    };
+
+    xhr.upload.addEventListener('progress', (e) => {
+        if (e.lengthComputable) {
+            dotnetRef.invokeMethodAsync('NotifyUploadProgress', e.loaded, e.total);
+        }
+    });
+
+    xhr.addEventListener('load', () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+            dotnetRef.invokeMethodAsync('NotifyUploadComplete', xhr.responseText);
+        } else if (xhr.status === 421) {
+            dotnetRef.invokeMethodAsync('NotifyUploadMisdirect', xhr.responseText, xhr.status);
+        } else {
+            dotnetRef.invokeMethodAsync('NotifyUploadError', `${xhr.status}: ${xhr.responseText}`);
+        }
+    });
+
+    xhr.addEventListener('error', () => {
+        dotnetRef.invokeMethodAsync('NotifyUploadError', 'Network error during upload');
+    });
+
+    xhr.addEventListener('abort', () => {
+        dotnetRef.invokeMethodAsync('NotifyUploadCancelled');
+    });
+
+    xhr.open('POST', url);
+
+    if (authToken) {
+        xhr.setRequestHeader('Authorization', authToken);
+    }
+
+    const blob = new Blob([byteArray], { type: mimeType || 'application/octet-stream' });
+    const formData = new FormData();
+    formData.append(fileName || 'file', blob, fileName || 'file');
+
+    xhr.send(formData);
+
+    return handle;
+}


### PR DESCRIPTION
Three related fixes for the upload flow, all in one branch since they stack on each other:

**1. Prevent double-submit on upload + handle DB race on CDN insert** (`8895354`)
- Disable the upload button while an upload is in flight so users can't slam it
- Catch the unique constraint violation on CDN item insert instead of crashing (concurrent uploads could race)

**2. Add upload progress bar and cancel support** (`c5d1084`)
- Wire up the existing `uploadWithProgress` JS function so the modal actually shows real progress
- Add a cancel button that calls `abortCurrentUpload()`
- Show progress percentage + uploaded/total size

**3. Wrap upload JS interop in reusable UploadService** (`1577f8f`)
- Extract all the messy `[JSInvokable]` callbacks out of FileUploadComponent into a proper scoped DI service
- UploadService.cs: `UploadAsync()` with CancellationToken support, `UploadProgressInfo` and `UploadResult` records
- UploadService.js: ES module (no more global `window._currentUploadAbort`), follows the ResizeObserver pattern already used in the project
- FileUploadComponent is now way cleaner since it just consumes the service

Tested: builds clean on Client.csproj