### PR TITLE
seo: add robots.txt and sitemap.xml

### DIFF
--- a/Valour/Client.Blazor/wwwroot/robots.txt
+++ b/Valour/Client.Blazor/wwwroot/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /account/
+Disallow: /settings/
+
+Sitemap: https://valour.gg/sitemap.xml

--- a/Valour/Client.Blazor/wwwroot/sitemap.xml
+++ b/Valour/Client.Blazor/wwwroot/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://valour.gg/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://valour.gg/login</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://valour.gg/register</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://valour.gg/terms</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://valour.gg/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Adds the two missing SEO files flagged in the audit:

**robots.txt** — allows all crawlers on public pages, blocks /api/, /account/, and /settings/ (no point indexing those). Points to sitemap.

**sitemap.xml** — lists the public-facing pages (home, login, register, terms, privacy). Valour is a SPA so most content is behind auth; this covers what crawlers can actually reach. Planet/channel URLs can be added later if we want public discovery indexed.

These go in Client.Blazor/wwwroot so they'll be served as static files at the root.