### PR TITLE
fix: NullReferenceException when non-member joins channel via SignalR

### DIFF
--- a/Valour/Server/Hubs/CoreHub.cs
+++ b/Valour/Server/Hubs/CoreHub.cs
@@ -144,8 +144,11 @@ public class CoreHub : Hub
         if (channel is null)
             return new TaskResult(false, "Failed to connect to Channel: Channel was not found.");
         
-        PlanetMember member = (await _db.PlanetMembers.FirstOrDefaultAsync(
-            x => x.UserId == authToken.UserId && x.PlanetId == channel.PlanetId)).ToModel();
+        var dbMember = await _db.PlanetMembers.FirstOrDefaultAsync(
+            x => x.UserId == authToken.UserId && x.PlanetId == channel.PlanetId);
+        if (dbMember is null)
+            return new TaskResult(false, "Failed to connect to Channel: You are not a member of this planet.");
+        PlanetMember member = dbMember.ToModel();
 
         if (!await _memberService.HasPermissionAsync(member, channel.ToModel(), ChatChannelPermissions.ViewMessages))
             return new TaskResult(false, "Failed to connect to Channel: Member lacks view permissions.");


### PR DESCRIPTION
The `JoinChannel` hub method calls `.ToModel()` on the result of `FirstOrDefaultAsync` without checking for null first. When a non-member tries to join a channel, this throws a NullReferenceException.

Fix: check the EF entity for null before calling `.ToModel()`, and return a clear error message if the user isn't a member of the planet.

Replaces #1530 (which had unrelated whitespace changes from line ending conversion).