### PR TITLE
fix: raise avatar upload limit to 20MB

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditProfileComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditProfileComponent.razor
@@ -447,15 +447,15 @@
     {
         var file = e.File;
 
-        if (file.Size > 10240000)
+        if (file.Size > 20971520)
         {
-            _pfpChangeResult = new TaskResult(false, "Max profile image size is 10mb.");
+            _pfpChangeResult = new TaskResult(false, "Max profile image size is 20mb.");
             StateHasChanged();
             return;
         }
 
         using var ms = new MemoryStream();
-        await file.OpenReadStream(10240000).CopyToAsync(ms);
+        await file.OpenReadStream(20971520).CopyToAsync(ms);
         _pendingImageType = file.ContentType;
         _cropDataUrl = $"data:{file.ContentType};base64,{Convert.ToBase64String(ms.ToArray())}";
 

--- a/Valour/Server/Cdn/Api/UploadApi.cs
+++ b/Valour/Server/Cdn/Api/UploadApi.cs
@@ -166,7 +166,7 @@ public class UploadApi
     };
 
     [FileUploadOperation.FileContentType]
-    [RequestSizeLimit(10240000)]
+    [RequestSizeLimit(20_971_520)] // 20 MB
     private static async Task<IResult> AvatarImageRoute(
         HttpContext ctx, 
         ValourDb valourDb, 


### PR DESCRIPTION
Fixes VALOUR-BACKEND-5P (327 Sentry events, 18 users affected since Feb).

Profile avatar uploads were hitting the 10MB Kestrel request body limit on `POST /upload/profile`. Users trying to upload bigger profile pics just got a generic failure.

**Changes:**
- Server: `[RequestSizeLimit]` on AvatarImageRoute `10240000` → `20_971_520` (20 MB)
- Client: file size check + `OpenReadStream` cap in EditProfileComponent `10240000` → `20971520` (20 MB)

Pretty minimal fix. Just raising the ceiling so people can actually upload their photos.