### PR TITLE
fix: push notification JS safety checks for unsupported browsers

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Upload/CompressComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Upload/CompressComponent.razor
@@ -85,7 +85,7 @@
                             
             Client.Logger.Log<CompressComponent>($"New size: {Data.File.Size} / {oldSize}", "cyan");
             
-            await Data.Input.ShowUploadMenu(Data.File.OpenReadStream(maxSize), MessageAttachmentType.Image, "image/jpeg", $"compressed-{Data.File.Name.Replace('.', '_')}.jpg", "image");
+            await Data.Input.ShowUploadMenu(Data.File.OpenReadStream(maxSize), (int)Data.File.Size, MessageAttachmentType.Image, "image/jpeg", $"compressed-{Data.File.Name.Replace('.', '_')}.jpg", "image");
             
             // Everything worked, close the modal
             Close();

--- a/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor
@@ -1,5 +1,6 @@
 @inherits Modal<FileUploadComponent.ModalParams>
 @inject IJSRuntime JsRuntime
+@inject UploadService UploadSvc
 @implements IDisposable
 
 @if (Data.Attachment is null)
@@ -39,11 +40,11 @@
         @if (_isUploading)
         {
             <div class="upload-progress-container">
-                <div class="upload-progress-bar" style="width: @(_uploadProgress)%"></div>
+                <div class="upload-progress-bar" style="width: @(_progress?.Percent ?? 0)%"></div>
             </div>
             <div class="upload-progress-info">
-                <span class="upload-progress-text">@_uploadProgress%</span>
-                <span class="upload-progress-bytes">@(FormatBytes(_uploadedBytes)) / @(FormatBytes(_totalBytes))</span>
+                <span class="upload-progress-text">@(_progress?.Percent ?? 0)%</span>
+                <span class="upload-progress-bytes">@(_progress?.FormattedUploaded ?? "0 B") / @(_progress?.FormattedTotal ?? "0 B")</span>
             </div>
         }
         @if (_uploadError is not null)
@@ -84,10 +85,10 @@
     private bool _imageReady;
     private bool _loaded = false;
     private bool _isUploading = false;
-    private int _uploadProgress;
-    private long _uploadedBytes;
-    private long _totalBytes;
+    private UploadProgressInfo? _progress;
     private string _uploadError;
+
+    private CancellationTokenSource? _uploadCts;
 
     protected override async Task OnInitializedAsync()
     {
@@ -123,51 +124,6 @@
         StateHasChanged();
     }
 
-    [JSInvokable]
-    public void OnUploadProgress(long loaded, long total)
-    {
-        _uploadedBytes = loaded;
-        _totalBytes = total;
-        _uploadProgress = total > 0 ? (int)Math.Round((double)loaded / total * 100) : 0;
-        StateHasChanged();
-    }
-
-    [JSInvokable]
-    public void OnUploadComplete(string response)
-    {
-        _isUploading = false;
-        _uploadProgress = 100;
-        
-        Data.OnUploadSuccess?.Invoke(response);
-        
-        StateHasChanged();
-        Close();
-    }
-
-    [JSInvokable]
-    public void OnUploadMisdirect(string responseBody, int statusCode)
-    {
-        _isUploading = false;
-        _uploadError = $"Server redirect ({statusCode}). Please try again.";
-        StateHasChanged();
-    }
-
-    [JSInvokable]
-    public void OnUploadError(string error)
-    {
-        _isUploading = false;
-        _uploadError = error;
-        StateHasChanged();
-    }
-
-    [JSInvokable]
-    public void OnUploadCancelled()
-    {
-        _isUploading = false;
-        _uploadProgress = 0;
-        StateHasChanged();
-    }
-
     public async Task OnKeyDown(KeyboardEventArgs e)
     {
         if (e.Key.ToLower() == "enter" && !_isUploading)
@@ -176,40 +132,52 @@
 
     public void OnClickCancel() => Close();
 
-    public async Task OnClickCancelUpload()
+    public void OnClickCancelUpload()
     {
-        await JsRuntime.InvokeVoidAsync("abortCurrentUpload");
+        _uploadCts?.Cancel();
     }
 
     public async Task OnClickConfirm()
     {
         if (_isUploading) return;
         
-        // If we have the new upload path, use JS progress upload
+        // New path: use UploadService for real progress
         if (!string.IsNullOrEmpty(Data.UploadUrl))
         {
             _isUploading = true;
-            _uploadProgress = 0;
-            _uploadedBytes = 0;
+            _progress = null;
             _uploadError = null;
+            _uploadCts = new CancellationTokenSource();
             StateHasChanged();
 
-            try
+            var result = await UploadSvc.UploadAsync(
+                Data.UploadUrl,
+                Data.Bytes,
+                Data.Attachment.MimeType,
+                Data.Attachment.FileName,
+                Data.AuthToken,
+                onProgress: p =>
+                {
+                    _progress = p;
+                    InvokeAsync(StateHasChanged);
+                },
+                cancellationToken: _uploadCts.Token);
+
+            _isUploading = false;
+            _uploadCts.Dispose();
+            _uploadCts = null;
+
+            if (result.Success)
             {
-                await JsRuntime.InvokeVoidAsync("uploadWithProgress",
-                    Data.UploadUrl,
-                    Data.Bytes,
-                    Data.Attachment.MimeType,
-                    Data.Attachment.FileName,
-                    _thisRef,
-                    Data.AuthToken);
+                Data.OnUploadSuccess?.Invoke(result.Response);
+                Close();
             }
-            catch (Exception ex)
+            else
             {
-                _isUploading = false;
-                _uploadError = ex.Message;
-                StateHasChanged();
+                _uploadError = result.Error ?? "Unknown error";
             }
+
+            StateHasChanged();
         }
         else
         {
@@ -220,15 +188,10 @@
         }
     }
 
-    private static string FormatBytes(long bytes)
-    {
-        if (bytes < 1024) return $"{bytes} B";
-        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
-        return $"{bytes / (1024.0 * 1024.0):F1} MB";
-    }
-
     public void Dispose()
     {
+        _uploadCts?.Cancel();
+        _uploadCts?.Dispose();
         _thisRef?.Dispose();
     }
 }

--- a/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor
@@ -36,11 +36,32 @@
                 }
             }
         </div>
+        @if (_isUploading)
+        {
+            <div class="upload-progress-container">
+                <div class="upload-progress-bar" style="width: @(_uploadProgress)%"></div>
+            </div>
+            <div class="upload-progress-info">
+                <span class="upload-progress-text">@_uploadProgress%</span>
+                <span class="upload-progress-bytes">@(FormatBytes(_uploadedBytes)) / @(FormatBytes(_totalBytes))</span>
+            </div>
+        }
+        @if (_uploadError is not null)
+        {
+            <div class="upload-error">Upload failed: @_uploadError</div>
+        }
     </MainArea>
     <ButtonArea>
         <div class="basic-modal-buttons">
-            <button @onclick="@OnClickCancel" class="v-btn">Cancel</button>
-            <button @onclick="@OnClickConfirm" class="v-btn primary" disabled="@_isUploading">Upload</button>
+            @if (_isUploading)
+            {
+                <button @onclick="@OnClickCancelUpload" class="v-btn danger">Cancel Upload</button>
+            }
+            else
+            {
+                <button @onclick="@OnClickCancel" class="v-btn">Cancel</button>
+                <button @onclick="@OnClickConfirm" class="v-btn primary">Upload</button>
+            }
         </div>
     </ButtonArea>
 </BasicModalLayout>
@@ -53,6 +74,9 @@
         public Func<Task> OnConfirm;
         public Message Message;
         public MessageAttachment Attachment;
+        public string UploadUrl { get; set; }
+        public string AuthToken { get; set; }
+        public Action<string> OnUploadSuccess { get; set; }
     }
 
     private DotNetObjectReference<FileUploadComponent> _thisRef;
@@ -60,9 +84,13 @@
     private bool _imageReady;
     private bool _loaded = false;
     private bool _isUploading = false;
+    private int _uploadProgress;
+    private long _uploadedBytes;
+    private long _totalBytes;
+    private string _uploadError;
 
-    protected override async Task OnInitializedAsync(){
-
+    protected override async Task OnInitializedAsync()
+    {
         Console.WriteLine(JsonSerializer.Serialize(Data.Attachment));
         
         _thisRef = DotNetObjectReference.Create(this);
@@ -95,18 +123,108 @@
         StateHasChanged();
     }
 
-    public async Task OnKeyDown(KeyboardEventArgs e){
-        if (e.Key.ToLower() == "enter")
+    [JSInvokable]
+    public void OnUploadProgress(long loaded, long total)
+    {
+        _uploadedBytes = loaded;
+        _totalBytes = total;
+        _uploadProgress = total > 0 ? (int)Math.Round((double)loaded / total * 100) : 0;
+        StateHasChanged();
+    }
+
+    [JSInvokable]
+    public void OnUploadComplete(string response)
+    {
+        _isUploading = false;
+        _uploadProgress = 100;
+        
+        Data.OnUploadSuccess?.Invoke(response);
+        
+        StateHasChanged();
+        Close();
+    }
+
+    [JSInvokable]
+    public void OnUploadMisdirect(string responseBody, int statusCode)
+    {
+        _isUploading = false;
+        _uploadError = $"Server redirect ({statusCode}). Please try again.";
+        StateHasChanged();
+    }
+
+    [JSInvokable]
+    public void OnUploadError(string error)
+    {
+        _isUploading = false;
+        _uploadError = error;
+        StateHasChanged();
+    }
+
+    [JSInvokable]
+    public void OnUploadCancelled()
+    {
+        _isUploading = false;
+        _uploadProgress = 0;
+        StateHasChanged();
+    }
+
+    public async Task OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key.ToLower() == "enter" && !_isUploading)
             await OnClickConfirm();
     }
 
     public void OnClickCancel() => Close();
 
-    public async Task OnClickConfirm(){
+    public async Task OnClickCancelUpload()
+    {
+        await JsRuntime.InvokeVoidAsync("abortCurrentUpload");
+    }
+
+    public async Task OnClickConfirm()
+    {
         if (_isUploading) return;
-        _isUploading = true;
-        await Data.OnConfirm.Invoke();
-        Close();
+        
+        // If we have the new upload path, use JS progress upload
+        if (!string.IsNullOrEmpty(Data.UploadUrl))
+        {
+            _isUploading = true;
+            _uploadProgress = 0;
+            _uploadedBytes = 0;
+            _uploadError = null;
+            StateHasChanged();
+
+            try
+            {
+                await JsRuntime.InvokeVoidAsync("uploadWithProgress",
+                    Data.UploadUrl,
+                    Data.Bytes,
+                    Data.Attachment.MimeType,
+                    Data.Attachment.FileName,
+                    _thisRef,
+                    Data.AuthToken);
+            }
+            catch (Exception ex)
+            {
+                _isUploading = false;
+                _uploadError = ex.Message;
+                StateHasChanged();
+            }
+        }
+        else
+        {
+            // Fallback: old method without progress
+            _isUploading = true;
+            await Data.OnConfirm.Invoke();
+            Close();
+        }
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        return $"{bytes / (1024.0 * 1024.0):F1} MB";
     }
 
     public void Dispose()

--- a/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor.css
+++ b/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor.css
@@ -42,3 +42,54 @@
     margin-top: 10px;
     margin-bottom: 10px;
 }
+
+.upload-progress-container {
+    width: 100%;
+    height: 8px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-top: 12px;
+}
+
+.upload-progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, #5865F2, #EB459E);
+    border-radius: 4px;
+    transition: width 0.2s ease;
+}
+
+.upload-progress-info {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 6px;
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.upload-progress-text {
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.upload-progress-bytes {
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.upload-error {
+    color: #ED4245;
+    font-size: 13px;
+    margin-top: 8px;
+    padding: 8px;
+    background: rgba(237, 66, 69, 0.1);
+    border-radius: 6px;
+}
+
+::deep .v-btn.danger {
+    background: #ED4245;
+    color: white;
+}
+
+::deep .v-btn.danger:hover {
+    background: #c03537;
+}

--- a/Valour/Client/Components/Notifications/PushSubscriptionsComponent.razor.js
+++ b/Valour/Client/Components/Notifications/PushSubscriptionsComponent.razor.js
@@ -9,12 +9,24 @@ export function init() {
             return existingSubscription !== null;
         },
         getPermissionState: () => {
+            if (typeof Notification === 'undefined') return 'denied';
             return Notification.permission;
         },
         askForPermission: async () => {
+            if (typeof Notification === 'undefined') return 'denied';
             return await Notification.requestPermission();
         },
         requestSubscription: async () => {
+            if (typeof Notification === 'undefined') {
+                return { success: false, error: 'Notifications not supported' };
+            }
+            if (!navigator.serviceWorker) {
+                return { success: false, error: 'Service workers not supported' };
+            }
+            const registration = await navigator.serviceWorker.ready;
+            if (!registration?.pushManager) {
+                return { success: false, error: 'Push not supported' };
+            }
             const permission = await Notification.requestPermission();
             if (permission !== 'granted') {
                 return {
@@ -22,7 +34,6 @@ export function init() {
                     error: 'Permission denied'
                 };
             }
-            const registration = await navigator.serviceWorker.ready;
             const existingSubscription = await registration.pushManager.getSubscription();
             try {
                 if (existingSubscription) {
@@ -58,7 +69,13 @@ export function init() {
             }
         },
         getSubscription: async () => {
+            if (!navigator.serviceWorker) {
+                return { success: false, error: 'Service workers not supported' };
+            }
             const registration = await navigator.serviceWorker.ready;
+            if (!registration?.pushManager) {
+                return { success: false, error: 'Push not supported' };
+            }
             const existingSubscription = await registration.pushManager.getSubscription();
             if (existingSubscription) {
                 return {
@@ -78,7 +95,9 @@ export function init() {
             }
         },
         unsubscribe: async () => {
+            if (!navigator.serviceWorker) return;
             const registration = await navigator.serviceWorker.ready;
+            if (!registration?.pushManager) return;
             const existingSubscription = await registration.pushManager.getSubscription();
             if (existingSubscription) {
                 await existingSubscription.unsubscribe();

--- a/Valour/Client/Components/Notifications/PushSubscriptionsComponent.razor.js
+++ b/Valour/Client/Components/Notifications/PushSubscriptionsComponent.razor.js
@@ -2,7 +2,9 @@ const publicKey = 'BBySvfFjJ4IihseXSujDGj4MsAd3ZAwDwy1Q2XxnMY6V3rCXjuqwm3utGvACA
 export function init() {
     return {
         notificationsEnabled: async () => {
+            if (!navigator.serviceWorker) return false;
             const registration = await navigator.serviceWorker.ready;
+            if (!registration?.pushManager) return false;
             const existingSubscription = await registration.pushManager.getSubscription();
             return existingSubscription !== null;
         },

--- a/Valour/Client/Components/Sidebar/Directory/ChannelDirectory.razor.css
+++ b/Valour/Client/Components/Sidebar/Directory/ChannelDirectory.razor.css
@@ -82,33 +82,6 @@
     top: -5px;
 }
 
-::deep .path.str {
-    border-radius: 0;
-    border-left: 2px solid var(--v-cyan);
-    width: 7px;
-    height: calc(100% - 14px);
-    position: absolute;
-    left: 15px;
-    top: 0;
-    border-bottom: 0;
-}
-
-::deep .path.str[depth="2"] {
-    border-color: var(--p-cyan);
-}
-
-::deep .path.str[depth="3"] {
-    border-color: var(--p-cyan-purple);
-}
-
-::deep .path.str[depth="4"] {
-    border-color: var(--p-purple);
-}
-
-::deep .path.str[depth="5"] {
-    border-color: var(--p-red);
-}
-
 ::deep .channel.nested .path[depth="2"] {
     border-color: var(--p-cyan);
 }
@@ -249,6 +222,49 @@
 
 ::deep .sub-list {
     position: relative;
+}
+
+::deep .direct-children {
+    position: relative;
+}
+
+::deep .tree-row {
+    position: relative;
+}
+
+::deep .tree-row::before {
+    content: '';
+    position: absolute;
+    left: 15px;
+    top: 0;
+    bottom: 0;
+    width: 0;
+    border-left: 2px solid var(--v-cyan);
+}
+
+::deep .tree-row[depth="2"]::before,
+::deep .tree-row.last[depth="2"]::before {
+    border-color: var(--p-cyan);
+}
+
+::deep .tree-row[depth="3"]::before,
+::deep .tree-row.last[depth="3"]::before {
+    border-color: var(--p-cyan-purple);
+}
+
+::deep .tree-row[depth="4"]::before,
+::deep .tree-row.last[depth="4"]::before {
+    border-color: var(--p-purple);
+}
+
+::deep .tree-row[depth="5"]::before,
+::deep .tree-row.last[depth="5"]::before {
+    border-color: var(--p-red);
+}
+
+::deep .tree-row.last::before {
+    bottom: auto;
+    height: 14px;
 }
 
 /* Icons */

--- a/Valour/Client/Components/Sidebar/Directory/ChannelDirectory.razor.css
+++ b/Valour/Client/Components/Sidebar/Directory/ChannelDirectory.razor.css
@@ -86,7 +86,7 @@
     border-radius: 0;
     border-left: 2px solid var(--v-cyan);
     width: 7px;
-    height: 100%;
+    height: calc(100% - 14px);
     position: absolute;
     left: 15px;
     top: 0;

--- a/Valour/Client/Components/Sidebar/Directory/ChannelDirectory.razor.css
+++ b/Valour/Client/Components/Sidebar/Directory/ChannelDirectory.razor.css
@@ -236,7 +236,7 @@
     content: '';
     position: absolute;
     left: 15px;
-    top: 0;
+    top: -8px;
     bottom: 0;
     width: 0;
     border-left: 2px solid var(--v-cyan);

--- a/Valour/Client/Components/Sidebar/Directory/ChannelDirectoryItem.razor
+++ b/Valour/Client/Components/Sidebar/Directory/ChannelDirectoryItem.razor
@@ -145,7 +145,7 @@
                 if (_children.Count > 0)
                 {
                     <div class="sub-list" ondragover="event.preventDefault();" depth="@(Depth + 1)">
-                        <div class="path str" style="height: @(GetLineHeightPx())px" depth="@(Depth + 1)"></div>
+                        <div class="path str" depth="@(Depth + 1)"></div>
                         
                         @for (int i = 0; i < _children.Count; i++)
                         {
@@ -267,36 +267,6 @@
     private void OnChannelDeleted()
     {
         RefreshParentsRecursive();
-    }
-
-    private float GetLineHeightPx()
-    {
-        var lastDirectDescendant = Planet.Channels.LastOrDefault(x => x.ParentId == Channel.Id);
-
-        if (lastDirectDescendant is null)
-            return 0;
-
-        // Count visible channels between this category and the last direct descendant
-        var channelsInRange = Planet.Channels
-            .Where(x => x.RawPosition > Channel.RawPosition
-                        && x.RawPosition < lastDirectDescendant.RawPosition
-                        && PlanetComponent.GetVisible(x));
-
-        float height = 0;
-        foreach (var ch in channelsInRange)
-        {
-            height += 27f;
-
-            // Voice channels with participants have an extra row of avatars
-            if (ISharedChannel.VoiceChannelTypes.Contains(ch.ChannelType))
-            {
-                var count = Client.VoiceStateService.GetParticipantCount(ch.Id);
-                if (count > 0)
-                    height += 27f;
-            }
-        }
-
-        return height;
     }
 
     private void OnContextMenu(ContextPressEventArgs e)

--- a/Valour/Client/Components/Sidebar/Directory/ChannelDirectoryItem.razor
+++ b/Valour/Client/Components/Sidebar/Directory/ChannelDirectoryItem.razor
@@ -145,17 +145,18 @@
                 if (_children.Count > 0)
                 {
                     <div class="sub-list" ondragover="event.preventDefault();" depth="@(Depth + 1)">
-                        <div class="path str" depth="@(Depth + 1)"></div>
-                        
                         @for (int i = 0; i < _children.Count; i++)
                         {
                             var ii = i;
                             var child = _children[ii];
+                            var isLast = (i == _children.Count - 1);
                             
-                            <ChannelDirectoryItem @key="@child.Id"
-                                             PlanetComponent="@PlanetComponent"
-                                             ParentComponent="@this"
-                                             Channel="@child" />
+                            <div class="tree-row @(isLast ? "last" : "")" depth="@(Depth + 1)">
+                                <ChannelDirectoryItem @key="@child.Id"
+                                                 PlanetComponent="@PlanetComponent"
+                                                 ParentComponent="@this"
+                                                 Channel="@child" />
+                            </div>
                         }
                     </div>
                 }

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
@@ -1,4 +1,4 @@
-﻿@inject IJSRuntime JsRuntime
+@inject IJSRuntime JsRuntime
 @implements IAsyncDisposable
 @inject ValourClient Client
 
@@ -537,16 +537,6 @@
         // Convert stream to byte array
         var bytes = new byte[data.Length];
         _ = await data.ReadAsync(bytes, 0, bytes.Length);
-        
-        var content = new MultipartFormDataContent();
-        
-        var byteContent = new ByteArrayContent(bytes);
-        if (!string.IsNullOrWhiteSpace(mime))
-        {
-            byteContent.Headers.ContentType = new MediaTypeHeaderValue(mime);
-        }
-
-        content.Add(byteContent, name, name);
 
         MessageAttachment newAttachment = new(type)
         {
@@ -555,13 +545,32 @@
             FileName = name,
         };
 
+        var uploadUrl = Client.BaseAddress + $"upload/{path}";
+        var authToken = Client.AuthService.Token;
+
         var modalData = new FileUploadComponent.ModalParams()
         {
             Bytes = bytes,
             Attachment = newAttachment,
             Message = PreviewMessage,
+            UploadUrl = uploadUrl,
+            AuthToken = authToken,
+            OnUploadSuccess = (location) =>
+            {
+                newAttachment.Location = location;
+                AddMessageAttachment(newAttachment);
+            },
             OnConfirm = async () =>
             {
+                // Fallback for old upload path (no progress)
+                var content = new MultipartFormDataContent();
+                var byteContent = new ByteArrayContent(bytes);
+                if (!string.IsNullOrWhiteSpace(mime))
+                {
+                    byteContent.Headers.ContentType = new MediaTypeHeaderValue(mime);
+                }
+                content.Add(byteContent, name, name);
+
                 var result = await Client.PrimaryNode.PostMultipartDataWithResponse<string>($"upload/{path}", content);
 
                 if (result.Success)

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
@@ -34,10 +34,9 @@
 
         <div class="upload-menu" style="@_uploadMenuStyle">
             <div class="content tenor" @onmousedown:stopPropagation="true">
-                @* Using label to click the hidden InputFile — more reliable than JS interop click() *@
-                <label for="upload-core" class="button upload-label">
+                <button class="button" @onmousedown="@OnClickUploadAsync">
                     Upload a File
-                </label>
+                </button>
                 <button class="button tenor" @onmousedown="@ShowTenorMenu">
                     Gifs via Tenor
                 </button>

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
@@ -10,7 +10,7 @@
 @using Valour.TenorTwo.Models
 @using Media = Valour.TenorTwo.Models.Media
 
-<InputFile id="upload-core" @ref="_inputFileRef" style="width: 1px; height: 1px; opacity: 0; position: absolute; overflow: hidden;" OnChange="LoadFiles"></InputFile>
+<InputFile id="upload-core" @ref="_inputFileRef" style="width: 0; height: 0; display: none;" OnChange="LoadFiles"></InputFile>
 
 <div class='channel-footer @(CanUserPost ? string.Empty : "no-perms")' style="@(_loading ? "pointer-events: none; opacity: 0.8" : string.Empty)">
     <div class="preview-message">
@@ -30,25 +30,24 @@
         }
     </div>
 
-    <div class="upload-menu" style="@_uploadMenuStyle">
-        <div class="content tenor" @onmousedown:stopPropagation="true">
-            <label class="button upload-label" style="display: block; text-align: center; cursor: pointer;">
-                Upload a File
-                <InputFile @ref="_inputFileRef" style="display: none" OnChange="LoadFiles"></InputFile>
-            </label>
-            <button class="button tenor" @onmousedown="@ShowTenorMenu">
-                Gifs via Tenor
-            </button>
-            <button class="button" @onmousedown="@OnClickSendCurrency">
-                Send Currency
-            </button>
-        </div>
-        <div class="carrot"></div>
-    </div>
-
     @if (!_loading)
     {
         <ChannelCurrentlyTypingComponent ParentComponent="ChatComponent" Channel="ChatComponent.Channel"></ChannelCurrentlyTypingComponent>
+
+        <div class="upload-menu" style="@_uploadMenuStyle">
+            <div class="content tenor" @onmousedown:stopPropagation="true">
+                <button class="button" @onmousedown="@OnClickUploadAsync">
+                    Upload a File
+                </button>
+                <button class="button tenor" @onmousedown="@ShowTenorMenu">
+                    Gifs via Tenor
+                </button>
+                <button class="button" @onmousedown="@OnClickSendCurrency">
+                    Send Currency
+                </button>
+            </div>
+            <div class="carrot"></div>
+        </div>
         
         <div style="position: relative">
             <TenorMenuComponent @key="@("tenor-menu-" + ChatComponent.WindowCtx.Id)" @ref="TenorMenu" ChannelWindow="ChatComponent"></TenorMenuComponent>

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
@@ -34,9 +34,10 @@
 
         <div class="upload-menu" style="@_uploadMenuStyle">
             <div class="content tenor" @onmousedown:stopPropagation="true">
-                <button class="button" @onmousedown="@OnClickUploadAsync">
+                <label class="button upload-label" style="display: block; text-align: center; cursor: pointer;">
                     Upload a File
-                </button>
+                    <InputFile @ref="_inputFileRef" style="display: none" OnChange="LoadFiles"></InputFile>
+                </label>
                 <button class="button tenor" @onmousedown="@ShowTenorMenu">
                     Gifs via Tenor
                 </button>
@@ -57,8 +58,6 @@
     
     <div class="textbox-holder" @onclick="@OnClickTextbox">
         <div class="textbox" @ref="_dropZoneElement">
-            <InputFile id="upload-core" @ref="_inputFileRef" style="width: 1px; height: 1px; opacity: 0; position: absolute; overflow: hidden;" OnChange="LoadFiles"></InputFile>
-            
             <div class="textbox-wrapper">
                 <div @ref="InnerInputRef" tabindex="1" role="textbox" contenteditable='@(CanUserPost ? "true" : "false")' class="textbox-inner" id="text-input-@ChatComponent.WindowCtx.Id" data-window="@ChatComponent.WindowCtx.Id" rows="1" @onclick:stopPropagation="true" @onclick:preventDefault="true" onclick="document.getElementById('text-input-@ChatComponent.WindowCtx.Id').focus()" autofocus>
                 </div>

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
@@ -527,16 +527,17 @@
             }
         }
         
-        await ShowUploadMenu(file.OpenReadStream(maxSize), attachmentType, file.ContentType, file.Name, uploadPath);
+        await ShowUploadMenu(file.OpenReadStream(maxSize), (int)file.Size, attachmentType, file.ContentType, file.Name, uploadPath);
 
         Refresh();
     }
 
-    public async Task ShowUploadMenu(Stream data, MessageAttachmentType type, string mime, string name, string path)
+    public async Task ShowUploadMenu(Stream data, int dataLength, MessageAttachmentType type, string mime, string name, string path)
     {
         // Convert stream to byte array
-        var bytes = new byte[data.Length];
-        _ = await data.ReadAsync(bytes, 0, bytes.Length);
+        using var ms = new MemoryStream();
+        await data.CopyToAsync(ms);
+        var bytes = ms.ToArray();
 
         MessageAttachment newAttachment = new(type)
         {

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
@@ -34,10 +34,10 @@
 
         <div class="upload-menu" style="@_uploadMenuStyle">
             <div class="content tenor" @onmousedown:stopPropagation="true">
-                @* Somewhat creative way to call main upload element *@
-                <button class="button" @onmousedown="@OnClickUploadAsync">
+                @* Using label to click the hidden InputFile — more reliable than JS interop click() *@
+                <label for="upload-core" class="button upload-label">
                     Upload a File
-                </button>
+                </label>
                 <button class="button tenor" @onmousedown="@ShowTenorMenu">
                     Gifs via Tenor
                 </button>

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
@@ -10,6 +10,8 @@
 @using Valour.TenorTwo.Models
 @using Media = Valour.TenorTwo.Models.Media
 
+<InputFile id="upload-core" @ref="_inputFileRef" style="width: 1px; height: 1px; opacity: 0; position: absolute; overflow: hidden;" OnChange="LoadFiles"></InputFile>
+
 <div class='channel-footer @(CanUserPost ? string.Empty : "no-perms")' style="@(_loading ? "pointer-events: none; opacity: 0.8" : string.Empty)">
     <div class="preview-message">
         @{

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
@@ -58,7 +58,7 @@
     
     <div class="textbox-holder" @onclick="@OnClickTextbox">
         <div class="textbox" @ref="_dropZoneElement">
-            <InputFile id="upload-core" @ref="_inputFileRef" style="width: 0; height: 0; display: none;" OnChange="LoadFiles"></InputFile>
+            <InputFile id="upload-core" @ref="_inputFileRef" style="width: 1px; height: 1px; opacity: 0; position: absolute; overflow: hidden;" OnChange="LoadFiles"></InputFile>
             
             <div class="textbox-wrapper">
                 <div @ref="InnerInputRef" tabindex="1" role="textbox" contenteditable='@(CanUserPost ? "true" : "false")' class="textbox-inner" id="text-input-@ChatComponent.WindowCtx.Id" data-window="@ChatComponent.WindowCtx.Id" rows="1" @onclick:stopPropagation="true" @onclick:preventDefault="true" onclick="document.getElementById('text-input-@ChatComponent.WindowCtx.Id').focus()" autofocus>

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
@@ -28,25 +28,25 @@
         }
     </div>
 
+    <div class="upload-menu" style="@_uploadMenuStyle">
+        <div class="content tenor" @onmousedown:stopPropagation="true">
+            <label class="button upload-label" style="display: block; text-align: center; cursor: pointer;">
+                Upload a File
+                <InputFile @ref="_inputFileRef" style="display: none" OnChange="LoadFiles"></InputFile>
+            </label>
+            <button class="button tenor" @onmousedown="@ShowTenorMenu">
+                Gifs via Tenor
+            </button>
+            <button class="button" @onmousedown="@OnClickSendCurrency">
+                Send Currency
+            </button>
+        </div>
+        <div class="carrot"></div>
+    </div>
+
     @if (!_loading)
     {
         <ChannelCurrentlyTypingComponent ParentComponent="ChatComponent" Channel="ChatComponent.Channel"></ChannelCurrentlyTypingComponent>
-
-        <div class="upload-menu" style="@_uploadMenuStyle">
-            <div class="content tenor" @onmousedown:stopPropagation="true">
-                <label class="button upload-label" style="display: block; text-align: center; cursor: pointer;">
-                    Upload a File
-                    <InputFile @ref="_inputFileRef" style="display: none" OnChange="LoadFiles"></InputFile>
-                </label>
-                <button class="button tenor" @onmousedown="@ShowTenorMenu">
-                    Gifs via Tenor
-                </button>
-                <button class="button" @onmousedown="@OnClickSendCurrency">
-                    Send Currency
-                </button>
-            </div>
-            <div class="carrot"></div>
-        </div>
         
         <div style="position: relative">
             <TenorMenuComponent @key="@("tenor-menu-" + ChatComponent.WindowCtx.Id)" @ref="TenorMenu" ChannelWindow="ChatComponent"></TenorMenuComponent>

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor
@@ -457,87 +457,97 @@
 
     private async Task LoadFiles(InputFileChangeEventArgs e)
     {
-        //var file = await e.File.RequestImageFileAsync("jpeg", 256, 256);
-
-        var file = e.File;
-        var maxBytes = UserSubscriptionTypes.GetMaxUploadBytes(Client.Me.SubscriptionType);
-        var maxSize = (int)Math.Min(maxBytes, int.MaxValue);
-
-        var attachmentType = MessageAttachmentType.File;
-
-        // Determine if audio or video or image
-
-        var mime = file.ContentType;
-        var uploadPath = "file";
-
-        // We only actually need to check the first letter,
-        // since only 'image/' starts with i
-        if (mime[0] == 'i')
+        try
         {
-            // Ensure that the mime type is supported by ImageSharp processing
-            if (CdnUtils.ImageSharpSupported.Contains(mime))
+            var file = e.File;
+            var maxBytes = UserSubscriptionTypes.GetMaxUploadBytes(Client.Me.SubscriptionType);
+            var maxSize = (int)Math.Min(maxBytes, int.MaxValue);
+
+            var attachmentType = MessageAttachmentType.File;
+
+            // Determine if audio or video or image
+
+            var mime = file.ContentType;
+            var uploadPath = "file";
+
+            // We only actually need to check the first letter,
+            // since only 'image/' starts with i
+            if (mime[0] == 'i')
             {
-                attachmentType = MessageAttachmentType.Image;
-                uploadPath = "image";
-            }
-        }
-        // Same thing here - only 'video/' starts with v
-        else if (mime[0] == 'v')
-        {
-            attachmentType = MessageAttachmentType.Video;
-        }
-        // Unfortunately 'audio/' and 'application/' both start with 'a'
-        else if (mime[0] == 'a' && mime[1] == 'u')
-        {
-            attachmentType = MessageAttachmentType.Audio;
-        }
-        
-        Console.WriteLine($"Selected file {file.Name} with size {file.Size}");
-        
-        if (file.Size > maxSize)
-        {
-            
-            // Special case for images: ability to compress!
-            if (attachmentType == MessageAttachmentType.Image)
-            {
-                var data = new CompressComponent.ModalParams()
+                // Ensure that the mime type is supported by ImageSharp processing
+                if (CdnUtils.ImageSharpSupported.Contains(mime))
                 {
-                    File = file,
-                    Input = this,
-                };
-                
-                ModalRoot.OpenModal<CompressComponent>(data);
-
-                return;
+                    attachmentType = MessageAttachmentType.Image;
+                    uploadPath = "image";
+                }
             }
-            else
+            // Same thing here - only 'video/' starts with v
+            else if (mime[0] == 'v')
             {
-                var data = 
-                new InfoModalComponent.ModalParams(
-                    $"File too large!",
-                    Client.Me.SubscriptionType is null
-                        ? "The max upload size is 10MB. To raise this limit, consider subscribing!"
-                        : $"Your max upload size is {maxBytes / (1024 * 1024)}MB.",
-                    "Okay",
-                    null
-                );
-                
-                ModalRoot.OpenModal<InfoModalComponent>(data);
-                return;
+                attachmentType = MessageAttachmentType.Video;
             }
-        }
-        
-        await ShowUploadMenu(file.OpenReadStream(maxSize), (int)file.Size, attachmentType, file.ContentType, file.Name, uploadPath);
+            // Unfortunately 'audio/' and 'application/' both start with 'a'
+            else if (mime[0] == 'a' && mime[1] == 'u')
+            {
+                attachmentType = MessageAttachmentType.Audio;
+            }
+            
+            Console.WriteLine($"[Upload] Selected file {file.Name} with size {file.Size}, type {attachmentType}");
+            
+            if (file.Size > maxSize)
+            {
+                // Special case for images: ability to compress!
+                if (attachmentType == MessageAttachmentType.Image)
+                {
+                    var data = new CompressComponent.ModalParams()
+                    {
+                        File = file,
+                        Input = this,
+                    };
+                    
+                    ModalRoot.OpenModal<CompressComponent>(data);
 
-        Refresh();
+                    return;
+                }
+                else
+                {
+                    var data = 
+                    new InfoModalComponent.ModalParams(
+                        $"File too large!",
+                        Client.Me.SubscriptionType is null
+                            ? "The max upload size is 10MB. To raise this limit, consider subscribing!"
+                            : $"Your max upload size is {maxBytes / (1024 * 1024)}MB.",
+                        "Okay",
+                        null
+                    );
+                    
+                    ModalRoot.OpenModal<InfoModalComponent>(data);
+                    return;
+                }
+            }
+            
+            Console.WriteLine($"[Upload] Opening stream for {file.Name}...");
+            await ShowUploadMenu(file.OpenReadStream(maxSize), (int)file.Size, attachmentType, file.ContentType, file.Name, uploadPath);
+            Console.WriteLine($"[Upload] ShowUploadMenu completed for {file.Name}");
+
+            Refresh();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Upload] ERROR in LoadFiles: {ex.Message}\n{ex.StackTrace}");
+        }
     }
 
     public async Task ShowUploadMenu(Stream data, int dataLength, MessageAttachmentType type, string mime, string name, string path)
     {
+        Console.WriteLine($"[Upload] ShowUploadMenu called: {name}, {dataLength} bytes, type={type}, path={path}");
+        
         // Convert stream to byte array
         using var ms = new MemoryStream();
         await data.CopyToAsync(ms);
         var bytes = ms.ToArray();
+        
+        Console.WriteLine($"[Upload] Stream copied, {bytes.Length} bytes read");
 
         MessageAttachment newAttachment = new(type)
         {
@@ -586,7 +596,9 @@
             }
         };
         
+        Console.WriteLine($"[Upload] Opening FileUploadComponent modal, bytes={bytes.Length}, url={uploadUrl}");
         ModalRoot.OpenModal<FileUploadComponent>(modalData);
+        Console.WriteLine($"[Upload] Modal open called");
     }
 
     public void RemoveAttachment(int id)

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor.css
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor.css
@@ -1,4 +1,4 @@
-﻿.channel-footer {
+.channel-footer {
     
 }
 
@@ -199,6 +199,11 @@
 
 .upload-menu .button:hover {
     background-color: var(--main-5);
+}
+
+.upload-label {
+    display: block;
+    text-align: center;
 }
 
 .upload-menu .carrot {

--- a/Valour/Client/ServiceCollectionExtensions.cs
+++ b/Valour/Client/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Valour.Client.Components.Calls;
 using Valour.Client.Components.Sidebar.Directory;
 using Valour.Client.ContextMenu;
 using Valour.Client.Sounds;
+using Valour.Client.Utility;
 using Valour.Sdk.Client;
 using Valour.Sdk.Services;
 
@@ -34,6 +35,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<RealtimeKitHostService>();
         services.AddScoped<GlobalCallSessionService>();
         services.AddScoped<RealtimeKitDeviceService>();
+        services.AddScoped<UploadService>();
 
         // new services
         services.AddSingleton(client);

--- a/Valour/Client/Utility/UploadService.cs
+++ b/Valour/Client/Utility/UploadService.cs
@@ -36,7 +36,7 @@ public class UploadService : IAsyncDisposable
         CancellationToken cancellationToken = default)
     {
         // Lazy-load the JS module on first use
-        _module ??= await _js.InvokeAsync<IJSObjectReference>("import", "./ts/UploadService.js");
+        _module ??= await _js.InvokeAsync<IJSObjectReference>("import", "./_content/Valour.Client/ts/UploadService.js");
 
         // If there's a previous upload running, cancel it
         CancelCurrent();

--- a/Valour/Client/Utility/UploadService.cs
+++ b/Valour/Client/Utility/UploadService.cs
@@ -1,0 +1,190 @@
+using Microsoft.JSInterop;
+using Valour.Shared.Utilities;
+
+namespace Valour.Client.Utility;
+
+/// <summary>
+/// Reusable upload service for Blazor WASM that provides real wire-level
+/// progress tracking and cancellation via XHR. Wrap all your uploads in this
+/// and you never have to touch JS interop again.
+/// </summary>
+public class UploadService : IAsyncDisposable
+{
+    private readonly IJSRuntime _js;
+    private IJSObjectReference? _module;
+    private IJSObjectReference? _currentUpload;
+    private DotNetObjectReference<UploadCallbacks>? _currentDotnetRef;
+    private CancellationTokenSource? _cts;
+
+    public UploadService(IJSRuntime jsRuntime)
+    {
+        _js = jsRuntime;
+    }
+
+    /// <summary>
+    /// Upload a file with real progress tracking. Returns an UploadResult
+    /// when the upload completes (success or failure).
+    /// Cancel via the CancellationToken.
+    /// </summary>
+    public async Task<UploadResult> UploadAsync(
+        string url,
+        byte[] data,
+        string mimeType,
+        string fileName,
+        string? authToken = null,
+        Action<UploadProgressInfo>? onProgress = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Lazy-load the JS module on first use
+        _module ??= await _js.InvokeAsync<IJSObjectReference>("import", "./ts/UploadService.js");
+
+        // If there's a previous upload running, cancel it
+        CancelCurrent();
+
+        var tcs = new TaskCompletionSource<UploadResult>();
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var callbacks = new UploadCallbacks(tcs, onProgress);
+        _currentDotnetRef = DotNetObjectReference.Create(callbacks);
+
+        _currentUpload = await _module.InvokeAsync<IJSObjectReference>(
+            "start",
+            url,
+            data,
+            mimeType,
+            fileName,
+            _currentDotnetRef,
+            authToken);
+
+        // Wire up cancellation
+        _cts.Token.Register(() =>
+        {
+            CancelCurrent();
+            if (!tcs.Task.IsCompleted)
+                tcs.TrySetResult(new UploadResult(false, null, "Upload cancelled"));
+        });
+
+        // Also handle the case where someone cancels the token before we even wire it
+        if (cancellationToken.IsCancellationRequested)
+        {
+            CancelCurrent();
+            return new UploadResult(false, null, "Upload cancelled");
+        }
+
+        return await tcs.Task;
+    }
+
+    /// <summary>
+    /// Cancel whatever upload is currently in flight.
+    /// </summary>
+    public void CancelCurrent()
+    {
+        try
+        {
+            _currentUpload?.InvokeVoidAsync("abort").AsTask().Wait(TimeSpan.FromSeconds(2));
+        }
+        catch
+        {
+            // Best effort - if abort fails the upload will complete or error on its own
+        }
+
+        _currentUpload = null;
+        CleanupDotnetRef();
+    }
+
+    private void CleanupDotnetRef()
+    {
+        _currentDotnetRef?.Dispose();
+        _currentDotnetRef = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        CancelCurrent();
+        _cts?.Cancel();
+        _cts?.Dispose();
+
+        try
+        {
+            if (_module is not null)
+                await _module.DisposeAsync();
+        }
+        catch (JSDisconnectedException) { }
+        catch (JSException) { }
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Internal callback target for JSInvokable calls from the JS module.
+    /// Bridges XHR events into the TaskCompletionSource and progress callback.
+    /// </summary>
+    private sealed class UploadCallbacks
+    {
+        private readonly TaskCompletionSource<UploadResult> _tcs;
+        private readonly Action<UploadProgressInfo>? _onProgress;
+
+        public UploadCallbacks(TaskCompletionSource<UploadResult> tcs, Action<UploadProgressInfo>? onProgress)
+        {
+            _tcs = tcs;
+            _onProgress = onProgress;
+        }
+
+        [JSInvokable("NotifyUploadProgress")]
+        public void NotifyUploadProgress(long loaded, long total)
+        {
+            _onProgress?.Invoke(new UploadProgressInfo(loaded, total));
+        }
+
+        [JSInvokable("NotifyUploadComplete")]
+        public void NotifyUploadComplete(string response)
+        {
+            _tcs.TrySetResult(new UploadResult(true, response, null));
+        }
+
+        [JSInvokable("NotifyUploadMisdirect")]
+        public void NotifyUploadMisdirect(string responseBody, int statusCode)
+        {
+            _tcs.TrySetResult(new UploadResult(false, null, $"Server redirect ({statusCode}). Please try again."));
+        }
+
+        [JSInvokable("NotifyUploadError")]
+        public void NotifyUploadError(string error)
+        {
+            _tcs.TrySetResult(new UploadResult(false, null, error));
+        }
+
+        [JSInvokable("NotifyUploadCancelled")]
+        public void NotifyUploadCancelled()
+        {
+            _tcs.TrySetResult(new UploadResult(false, null, "Upload cancelled"));
+        }
+    }
+}
+
+/// <summary>
+/// The result of an upload operation. Clean and simple.
+/// </summary>
+public record UploadResult(bool Success, string? Response, string? Error)
+{
+    public bool IsMisdirect => !Success && Error?.Contains("redirect") == true;
+}
+
+/// <summary>
+/// Real-time progress info from the XHR upload progress event.
+/// BytesUploaded / TotalBytes are the real wire-level numbers.
+/// </summary>
+public record UploadProgressInfo(long BytesUploaded, long TotalBytes)
+{
+    public int Percent => TotalBytes > 0 ? (int)Math.Round((double)BytesUploaded / TotalBytes * 100) : 0;
+
+    public string FormattedUploaded => FormatBytes(BytesUploaded);
+    public string FormattedTotal => FormatBytes(TotalBytes);
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        return $"{bytes / (1024.0 * 1024.0):F1} MB";
+    }
+}

--- a/Valour/Client/wwwroot/css/globals.css
+++ b/Valour/Client/wwwroot/css/globals.css
@@ -716,6 +716,10 @@
     border-radius: 0 0 8px 0;
 }
 
+.basic-modal-buttons > button:only-child {
+    border-radius: 0 0 8px 8px;
+}
+
 @keyframes windowZoomFadeIn {
     0% {
         transform: scale(0);

--- a/Valour/Client/wwwroot/js/main.js
+++ b/Valour/Client/wwwroot/js/main.js
@@ -1,4 +1,4 @@
-﻿document.addEventListener('contextmenu', event => event.preventDefault());
+document.addEventListener('contextmenu', event => event.preventDefault());
 
 window.clipboardCopy = {
     copyText: function (text) {
@@ -282,6 +282,66 @@ function getImageSize(blobUrl, ref) {
         ref.invokeMethodAsync('SetImageSize', this.width, this.height);
     }
     image.src = blobUrl;
+}
+
+// Upload with progress tracking using XMLHttpRequest
+// Called from .NET with: uploadWithProgress(url, byteArray, mimeType, fileName, dotnetRef, authToken)
+function uploadWithProgress(url, byteArray, mimeType, fileName, dotnetRef, authToken) {
+    return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+
+        xhr.upload.addEventListener('progress', (e) => {
+            if (e.lengthComputable) {
+                dotnetRef.invokeMethodAsync('OnUploadProgress', e.loaded, e.total);
+            }
+        });
+
+        xhr.addEventListener('load', () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                dotnetRef.invokeMethodAsync('OnUploadComplete', xhr.responseText);
+                resolve(xhr.responseText);
+            } else if (xhr.status === 421) {
+                dotnetRef.invokeMethodAsync('OnUploadMisdirect', xhr.responseText, xhr.status);
+                resolve(null);
+            } else {
+                dotnetRef.invokeMethodAsync('OnUploadError', `${xhr.status}: ${xhr.responseText}`);
+                reject(new Error(`${xhr.status}: ${xhr.responseText}`));
+            }
+        });
+
+        xhr.addEventListener('error', () => {
+            dotnetRef.invokeMethodAsync('OnUploadError', 'Network error during upload');
+            reject(new Error('Network error during upload'));
+        });
+
+        xhr.addEventListener('abort', () => {
+            dotnetRef.invokeMethodAsync('OnUploadCancelled');
+            reject(new Error('Upload cancelled'));
+        });
+
+        xhr.open('POST', url);
+
+        if (authToken) {
+            xhr.setRequestHeader('Authorization', authToken);
+        }
+
+        // Build FormData from the byte array
+        const blob = new Blob([byteArray], { type: mimeType || 'application/octet-stream' });
+        const formData = new FormData();
+        formData.append(fileName || 'file', blob, fileName || 'file');
+
+        xhr.send(formData);
+
+        // Store abort function so .NET can cancel
+        window._currentUploadAbort = () => xhr.abort();
+    });
+}
+
+function abortCurrentUpload() {
+    if (window._currentUploadAbort) {
+        window._currentUploadAbort();
+        window._currentUploadAbort = null;
+    }
 }
 
 /* Useful functions for layout items */

--- a/Valour/Client/wwwroot/js/main.js
+++ b/Valour/Client/wwwroot/js/main.js
@@ -284,66 +284,6 @@ function getImageSize(blobUrl, ref) {
     image.src = blobUrl;
 }
 
-// Upload with progress tracking using XMLHttpRequest
-// Called from .NET with: uploadWithProgress(url, byteArray, mimeType, fileName, dotnetRef, authToken)
-function uploadWithProgress(url, byteArray, mimeType, fileName, dotnetRef, authToken) {
-    return new Promise((resolve, reject) => {
-        const xhr = new XMLHttpRequest();
-
-        xhr.upload.addEventListener('progress', (e) => {
-            if (e.lengthComputable) {
-                dotnetRef.invokeMethodAsync('OnUploadProgress', e.loaded, e.total);
-            }
-        });
-
-        xhr.addEventListener('load', () => {
-            if (xhr.status >= 200 && xhr.status < 300) {
-                dotnetRef.invokeMethodAsync('OnUploadComplete', xhr.responseText);
-                resolve(xhr.responseText);
-            } else if (xhr.status === 421) {
-                dotnetRef.invokeMethodAsync('OnUploadMisdirect', xhr.responseText, xhr.status);
-                resolve(null);
-            } else {
-                dotnetRef.invokeMethodAsync('OnUploadError', `${xhr.status}: ${xhr.responseText}`);
-                reject(new Error(`${xhr.status}: ${xhr.responseText}`));
-            }
-        });
-
-        xhr.addEventListener('error', () => {
-            dotnetRef.invokeMethodAsync('OnUploadError', 'Network error during upload');
-            reject(new Error('Network error during upload'));
-        });
-
-        xhr.addEventListener('abort', () => {
-            dotnetRef.invokeMethodAsync('OnUploadCancelled');
-            reject(new Error('Upload cancelled'));
-        });
-
-        xhr.open('POST', url);
-
-        if (authToken) {
-            xhr.setRequestHeader('Authorization', authToken);
-        }
-
-        // Build FormData from the byte array
-        const blob = new Blob([byteArray], { type: mimeType || 'application/octet-stream' });
-        const formData = new FormData();
-        formData.append(fileName || 'file', blob, fileName || 'file');
-
-        xhr.send(formData);
-
-        // Store abort function so .NET can cancel
-        window._currentUploadAbort = () => xhr.abort();
-    });
-}
-
-function abortCurrentUpload() {
-    if (window._currentUploadAbort) {
-        window._currentUploadAbort();
-        window._currentUploadAbort = null;
-    }
-}
-
 /* Useful functions for layout items */
 function determineFlip(elementId, safeWidth){
     const element = document.getElementById(elementId);

--- a/Valour/Client/wwwroot/ts/UploadService.js
+++ b/Valour/Client/wwwroot/ts/UploadService.js
@@ -1,0 +1,60 @@
+/**
+ * UploadService JS module
+ * Provides real XHR upload progress + cancel support for Blazor WASM.
+ * Each call to start() returns an upload handle with its own XHR and abort function.
+ */
+
+/**
+ * @param {string} url - Upload endpoint
+ * @param {Uint8Array} byteArray - File data
+ * @param {string} mimeType - MIME type
+ * @param {string} fileName - File name
+ * @param {object} dotnetRef - DotNetObjectReference for callbacks
+ * @param {string} authToken - Optional Authorization header value
+ * @returns {object} Upload handle with an abort() method
+ */
+export function start(url, byteArray, mimeType, fileName, dotnetRef, authToken) {
+    const xhr = new XMLHttpRequest();
+
+    const handle = {
+        abort: () => xhr.abort()
+    };
+
+    xhr.upload.addEventListener('progress', (e) => {
+        if (e.lengthComputable) {
+            dotnetRef.invokeMethodAsync('NotifyUploadProgress', e.loaded, e.total);
+        }
+    });
+
+    xhr.addEventListener('load', () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+            dotnetRef.invokeMethodAsync('NotifyUploadComplete', xhr.responseText);
+        } else if (xhr.status === 421) {
+            dotnetRef.invokeMethodAsync('NotifyUploadMisdirect', xhr.responseText, xhr.status);
+        } else {
+            dotnetRef.invokeMethodAsync('NotifyUploadError', `${xhr.status}: ${xhr.responseText}`);
+        }
+    });
+
+    xhr.addEventListener('error', () => {
+        dotnetRef.invokeMethodAsync('NotifyUploadError', 'Network error during upload');
+    });
+
+    xhr.addEventListener('abort', () => {
+        dotnetRef.invokeMethodAsync('NotifyUploadCancelled');
+    });
+
+    xhr.open('POST', url);
+
+    if (authToken) {
+        xhr.setRequestHeader('Authorization', authToken);
+    }
+
+    const blob = new Blob([byteArray], { type: mimeType || 'application/octet-stream' });
+    const formData = new FormData();
+    formData.append(fileName || 'file', blob, fileName || 'file');
+
+    xhr.send(formData);
+
+    return handle;
+}


### PR DESCRIPTION
Adds guards to ALL functions in PushSubscriptionsComponent.razor.js, not just notificationsEnabled().

**Fixes:**
- VALOUR-BLAZOR-5M — `registration.pushManager.getSubscription()` crashes when pushManager is undefined (826 events, 810 users)
- VALOUR-BLAZOR-3V — `Can't find variable: Notification` crashes on Safari/browsers without Notification API (7 events, 7 users)

**What changed:**
- `getPermissionState()` — returns 'denied' if Notification API doesn't exist
- `askForPermission()` — returns 'denied' if Notification API doesn't exist  
- `requestSubscription()` — early returns with error if Notification, serviceWorker, or pushManager are unavailable
- `getSubscription()` — early returns with error if serviceWorker or pushManager are unavailable
- `unsubscribe()` — silently returns if serviceWorker or pushManager are unavailable
- `notificationsEnabled()` — already had the pushManager guard from Sora's earlier fix

The previous fix (commit c21b626a) only added a guard to notificationsEnabled(). But every other function in the same file was still hitting the same crash paths on unsupported browsers. This covers them all.