### PR TITLE
Fix monospace font usage in code blocks

### DIFF
--- a/Valour/Client/wwwroot/css/app.css
+++ b/Valour/Client/wwwroot/css/app.css
@@ -1158,6 +1158,7 @@ img.emoji {
     margin: 0;
     word-break: break-word;
     background: #242424;
+    font-family: revert;
 }
 
 .message .fragments pre {

--- a/Valour/Client/wwwroot/js/channel.js
+++ b/Valour/Client/wwwroot/js/channel.js
@@ -7,7 +7,14 @@
     const clone = el.cloneNode(true);
     clone.classList.add('hljs-clone');
     clone.style.display = 'inherit';
-    hljs.highlightElement(clone);
+
+    // Preserves padding for inline code blocks
+    // and avoids false positive syntax highlighting
+    if ((el.parentElement instanceof HTMLPreElement)) {
+        hljs.highlightElement(clone);
+    } else {
+        clone.classList.add('hljs');
+    }
 
     el.parentElement.insertBefore(clone, el.nextSibling);
     el.style.display = 'none';


### PR DESCRIPTION
This fixes wrong font selection for code fragments, both inline and code blocks.

<details>
<summary>Before</summary>
<img width="465" height="362" alt="image" src="https://github.com/user-attachments/assets/03755155-9d80-49c4-bc8e-46fe84f30d04" />
<img width="473" height="25" alt="image" src="https://github.com/user-attachments/assets/25aa6d7a-5999-4993-9e89-f868d7661f54" />

</details>

<details>
<summary>After</summary>
<img width="612" height="360" alt="image" src="https://github.com/user-attachments/assets/b3feda61-5b1b-403a-9aa2-0c1b48b99e48" />
<img width="500" height="32" alt="image" src="https://github.com/user-attachments/assets/c87b5172-59c7-4bc0-be34-96338416b6df" />

</details>