### PR TITLE
Fix an error storm when moving caret up and down inside the input field

### DIFF
--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor.js
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor.js
@@ -346,7 +346,7 @@ export function init(dotnet, inputEl) {
                         if (e.code === "ArrowUp") {
                             await ctx.dotnet.invokeMethodAsync('OnUpArrowNonMention');
                         }
-                        await this.caretMoveHandler();
+                        await ctx.caretMoveHandler();
                     }
                     break;
                 case "ArrowLeft":


### PR DESCRIPTION
`TypeError: this.caretMoveHandler is not a function` happens every time you move your cursor with arrows inside the input field.