### PR TITLE
Fix font selection for code blocks with syntax highlighting

### DIFF
--- a/Valour/Client/wwwroot/css/app.css
+++ b/Valour/Client/wwwroot/css/app.css
@@ -1158,6 +1158,10 @@ img.emoji {
     margin: 0;
     word-break: break-word;
     background: #242424;
+}
+
+.message .fragments code,
+.message .fragments code span[class*="hljs"] {
     font-family: revert;
 }
 


### PR DESCRIPTION
Part two of the #1545. This time will be fixing the syntax highlighting in code blocks.

Before:
<img width="879" height="236" alt="image" src="https://github.com/user-attachments/assets/a6c70644-a8eb-4123-93ba-e6cfbfde08c8" />


After:
<img width="982" height="232" alt="image" src="https://github.com/user-attachments/assets/4340a2de-9bfc-4133-a446-2652ca3fa33f" />
